### PR TITLE
Enable tabbing through project list

### DIFF
--- a/src/projects/project-pull-requests.html
+++ b/src/projects/project-pull-requests.html
@@ -13,6 +13,9 @@
       }
       paper-dropdown-menu {
         --paper-input-container-input-color: white;
+        --paper-input-container-underline-focus: {
+          background-color: white;
+        }
 
         --paper-input-container-label: {
           color: white;

--- a/src/projects/project-pull-requests.html
+++ b/src/projects/project-pull-requests.html
@@ -43,7 +43,7 @@
     </paper-toolbar>
     <div class="list">
       <template is="dom-repeat" items="[[_filter(pullrequests, status)]]" as="pr">
-        <project-pull-request-list-item pr="[[pr]]" show-status="[[_equals('All', status)]]"></project-pull-request-list-item>
+        <project-pull-request-list-item tabindex="0" pr="[[pr]]" show-status="[[_equals('All', status)]]"></project-pull-request-list-item>
       </template>
     </div>
   </template>

--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -55,16 +55,17 @@
     <div class="container">
       <div class="list">
         <template is="dom-repeat" items="[[projects]]" as="project">
-          <project-list-item project="[[project]]" selected="[[_isActiveProject(name.name, project, activeProject)]]" on-tap="chooseProject"></project-list-item>
+          <project-list-item project="[[project]]" selected="[[_isActiveProject(name.name, project, activeProject)]]" on-tap="chooseProject"
+                             tabindex="0" on-keydown="maybeOpenProject"></project-list-item>
         </template>
         <div class="last-project-item">
           <div class="dot"></div>
         </div>
       </div>
 
-      <div class="project">
+      <div class="project" id="project">
         <template is="dom-if" if="[[_has(owner.owner, name.name)]]" restamp="true">
-          <project-pull-requests owner="[[owner.owner]]" name="[[name.name]]"></project-pull-requests>
+          <project-pull-requests tabindex="0" owner="[[owner.owner]]" name="[[name.name]]"></project-pull-requests>
           <project-overview-page owner="[[owner.owner]]" name="[[name.name]]"></project-overview-page>
         </template>
         <template is="dom-if" if="[[!_has(owner.owner, name.name)]]" restamp="true">
@@ -318,6 +319,12 @@
         this.set('owner.owner', e.model.project.owner);
         this.set('name.name', e.model.project.name);
         this.activeProject = e.model.project;
+      },
+      maybeOpenProject: function(e) {
+        if (e.keyCode === 13) {
+          this.chooseProject(e);
+          this.querySelector('project-pull-requests').focus();
+        }
       },
       _has: function(owner, name) {
         return owner && name;


### PR DESCRIPTION
You can now tab through the list of projects. When you hit enter, the current project is selected and the focus is transferred to the project pull request overview. There you can tab into the dropdown menu or the next pull request. 
