### PR TITLE
Fix issue with race condition on tab

### DIFF
--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -323,7 +323,9 @@
       maybeOpenProject: function(e) {
         if (e.keyCode === 13) {
           this.chooseProject(e);
-          this.querySelector('project-pull-requests').focus();
+          this.async(function() {
+            this.querySelector('project-pull-requests').focus();
+          });
         }
       },
       _has: function(owner, name) {


### PR DESCRIPTION
It was possible that the pullrequest overview was not visible yet which resulted in a null on the query Selector. By calling async, we wait till all events are flushed and the dom changes are processed.
