### PR TITLE
Use iron-lazy-pages instead of iron-pages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "paper-elements": "polymerelements/paper-elements#^1.0.7",
     "carbon-elements": "polymerelements/carbon-elements#^0.1.0",
     "iron-elements": "polymerelements/iron-elements#^1.0.10",
-    "carbon-route": "TimvdLippe/carbon-route#subroute-updating"
+    "carbon-route": "TimvdLippe/carbon-route#subroute-updating",
+    "iron-lazy-pages": "^1.0.2"
   },
   "resolutions": {
     "carbon-route": "subroute-updating"

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -1,8 +1,10 @@
-<link rel="import" href="../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../bower_components/paper-styles/color.html">
+<!-- Load these elements first to have fetch sub-pages as fast as possible -->
+<link rel="import" href="../bower_components/iron-lazy-pages/iron-lazy-pages.html">
 <link rel="import" href="../bower_components/carbon-route/carbon-location.html">
 <link rel="import" href="../bower_components/carbon-route/carbon-route.html">
-<link rel="import" href="../bower_components/iron-pages/iron-pages.html">
+
+<link rel="import" href="../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../bower_components/paper-styles/color.html">
 <link rel="import" href="../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../bower_components/paper-tabs/paper-tab.html">
 <link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
@@ -11,9 +13,6 @@
 <link rel="import" href="../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
 <link rel="import" href="../bower_components/paper-card/paper-card.html">
 
-<link rel="import" href="home-page.html">
-<link rel="import" href="projects/projects-page.html">
-<link rel="import" href="pull-requests-page.html">
 <link rel="stylesheet" href="../bower_components/font-roboto/roboto.html">
 
 <dom-module id="rite-app">
@@ -61,7 +60,7 @@
         flex: 0;
         background-color: var(--primary-background-color);
       }
-      iron-pages {
+      iron-lazy-pages {
         flex: 1;
         display: flex;
       }
@@ -84,18 +83,27 @@
         </paper-tabs>
       </div>
 
-      <iron-pages selected="[[page.page]]"
+      <iron-lazy-pages selected="[[page.page]]"
                   attr-for-selected="data-route"
                   fallback-selection="404">
-        <home-page data-route=""></home-page>
-        <projects-page data-route="projects" route="{{tail}}"></projects-page>
-        <pull-requests-page data-route="pull-requests"></pull-requests-page>
-        <section data-route="404">
+        <template is="iron-lazy-page" data-route=""
+                  path="src/home-page.html">
+          <home-page></home-page>
+        </template>
+        <template is="iron-lazy-page" data-route="projects"
+                  path="src/projects/projects-page.html">
+          <projects-page route="{{tail}}"></projects-page>
+        </template>
+        <template is="iron-lazy-page" data-route="pull-requests"
+                  path="src/pull-requests-page.html">
+          <pull-requests-page></pull-requests-page>
+        </template>
+        <template is="iron-lazy-page" data-route="404">
           Oops you hit a 404!
 
           <a href="/">Head back home</a>
-        </section>
-      </iron-pages>
+        </template>
+      </iron-lazy-pages>
     </paper-header-panel>
   </template>
   <script>


### PR DESCRIPTION
Lazy-loading results in a lower first load time, since not all pages have to be loaded (only those you open). The benefit will be increasing over time when more pages are added.
