### PR TITLE
Fix pull request page sortable bugs

### DIFF
--- a/src/pull-request/pull-request-chunk.html
+++ b/src/pull-request/pull-request-chunk.html
@@ -25,7 +25,7 @@
       }
     </style>
     <content select=".title"></content>
-    <sortable-js id="sortable" group="chunk" draggable=".diff" force-fallback>
+    <sortable-js group="chunk" draggable=".diff" force-fallback>
       <template is="dom-repeat" items="[[chunk.diff]]">
         <div class="diff">[[item]]</div>
       </template>
@@ -39,7 +39,7 @@
         title: String
       },
       attached: function() {
-        this.$.sortable.getEffectiveChildren().forEach(function(el) {
+        document.querySelector('sortable-js').getEffectiveChildren().forEach(function(el) {
           if ((' ' + el.className + ' ').indexOf(' diff ') > -1) {
             Sortable.create(el, {
               group: 'chunk'

--- a/src/pull-request/pull-request-chunk.html
+++ b/src/pull-request/pull-request-chunk.html
@@ -2,10 +2,14 @@
   <template>
     <style>
       :host {
-        display: inline-block;
-        width: 250px;
+        display: block;
+        flex: auto;
+        flex-basis: 250px;
+        flex-grow: 0;
+        flex-shrink: 0;
         height: 250px;
         border: black 1px solid;
+        margin: 5px;
       }
       .diff {
         height: 50px;

--- a/src/pull-request/pull-request-page.html
+++ b/src/pull-request/pull-request-page.html
@@ -20,6 +20,12 @@
         display: block;
         border-bottom: black 1px solid;
       }
+      .diff--sortable {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-content: space-between;
+      }
     </style>
     <div class="overview">
       <h1>[[pr.title]]</h1>
@@ -31,7 +37,7 @@
       </div>
     </div>
     <div class="diff">
-      <sortable-js draggable="pull-request-chunk" handle=".title">
+      <sortable-js draggable="pull-request-chunk" handle=".title" class="diff--sortable">
         <template is="dom-repeat" items="[[pr.chunks]]" as="chunk">
           <pull-request-chunk class="draggable" chunk="[[chunk]]" title="[[index]]">
             <div class="title">[[index]]</div>


### PR DESCRIPTION
This PR fixes two bugs with the sortable pr chunks.
- [x] PR chunks no longer move randomly when children are dragged between them. Chunks are also aligned in a flexbox pattern, where it will fit as many 250x250 chunk elements on a row as possible, and then clips the remains to the next row, making sure all chunks are neatly arranged in a grid
- [x] diff children in chunks no longer disappear when you drag/drop them. This was due to two chunks selecting on the id `#sortable`, which causes a conflict, since the Sortable library sees the target and the origin chunks as the same (in a race condition where the first interaction was not from the first `#sortable` element
