### PR TITLE
Fix routing with updated carbon-route

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,14 +19,14 @@
     "paper-elements": "polymerelements/paper-elements#^1.0.7",
     "carbon-elements": "polymerelements/carbon-elements#^0.1.0",
     "iron-elements": "polymerelements/iron-elements#^1.0.10",
-    "carbon-route": "TimvdLippe/carbon-route#subroute-updating",
+    "carbon-route": "TimvdLippe/carbon-route#reset-tail",
     "iron-lazy-pages": "^1.0.2",
     "Sortable": "TimvdLippe/Sortable#fix-es5-compilation",
     "marked-element": "TimvdLippe/marked-element#expose-callback",
     "prism-element": "TimvdLippe/prism-element#fork"
   },
   "resolutions": {
-    "carbon-route": "subroute-updating",
+    "carbon-route": "reset-tail",
     "marked-element": "expose-callback",
     "prism-element": "fork"
   },

--- a/src/projects/project-pull-requests.html
+++ b/src/projects/project-pull-requests.html
@@ -65,7 +65,7 @@
 
     </style>
     <preview-list hide-end-indicator>
-      <iron-icon hidden$="{{_hideButton(hideProjectButton)}}" class$="back-button [[projectButtonClicked]]" icon="icon:icons:arrow-back" on-tap="_showProjects"></iron-icon>
+      <iron-icon hidden$="{{!hideProjectButton}}" class$="back-button [[projectButtonClicked]]" icon="icon:icons:arrow-back" on-tap="_showProjects"></iron-icon>
       <h2>[[name]]</h2>
       <div class=dropdown>
         <paper-dropdown-menu label="Pull request status" value="{{status}}">
@@ -145,9 +145,6 @@
       },
       _resetButton: function() {
         this.projectButtonClicked = false;
-      },
-      _hideButton: function(clicked){
-        return this._equals(clicked,undefined);
       }
     });
   </script>

--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -47,29 +47,23 @@
       preview-list {
         overflow-y: auto;
         overflow-x: hidden;
+        -webkit-transition: flex 0.5s ease;
+        -moz-transition: flex 0.5s ease;
+        -o-transition: flex 0.5s ease;
+        transition: flex 0.5s ease;
       }
       a {
         color: inherit;
       }
       preview-list.false {
         flex: 0 0;
-        -webkit-transition: flex 0.5s ease;
-        -moz-transition: flex 0.5s ease;
-        -o-transition: flex 0.5s ease;
-        transition: flex 0.5s ease;
-      }
-      preview-list.true {
-        -webkit-transition: flex 0.5s ease;
-        -moz-transition: flex 0.5s ease;
-        -o-transition: flex 0.5s ease;
-        transition: flex 0.5s ease;
       }
       search-box {
         margin-top:19.920px;
       }
     </style>
-    <carbon-route route="{{route}}" pattern="/:owner/:name" data="{{projectTitle}}" tail="{{nameTail}}"></carbon-route>
-    <carbon-route route="{{nameTail}}" pattern="/pulls/:pr" data="{{pr}}" tail="{{prTail}}"></carbon-route>
+    <carbon-route route="{{route}}" pattern="/:owner/:name" data="{{projectTitle}}" tail="{{nameTail}}" active="{{projectSelected}}"></carbon-route>
+    <carbon-route route="{{nameTail}}" pattern="/pulls/:pr" data="{{pr}}" tail="{{prTail}}" active="{{pullRequestSelected}}"></carbon-route>
 
     <authenticated-ajax
       id="ajaxPullRequest"
@@ -87,13 +81,13 @@
         </template>
       </preview-list>
       <div class="container">
-        <project-pull-requests hidden$="[[!projectTitle.name]]" route="{{nameTail}}" tabindex="0"
+        <project-pull-requests hidden$="[[!projectSelected]]" route="{{nameTail}}" tabindex="0"
                                owner="[[projectTitle.owner]]" name="[[projectTitle.name]]" pullrequests="[[pullrequests]]"
                                project-button-clicked="{{projectButtonClicked}}"
-                               hide-project-button="[[pr.pr]]"></project-pull-requests>
+                               hide-project-button="[[pullRequestSelected]]"></project-pull-requests>
 
         <iron-pages class="project"
-                    selected="[[_getCurrentView(projectTitle, pr)]]"
+                    selected="[[_getCurrentView(projectSelected, pullRequestSelected)]]"
                     attr-for-selected="data-route">
             <no-project-selected data-route="no-selected"></no-project-selected>
             <project-overview-page data-route="overview" tabindex="0"
@@ -123,7 +117,7 @@
         },
         shouldShowProjects: {
           type: String,
-          computed: '_shouldShowProjects(projectTitle, pr, projectButtonClicked)'
+          computed: '_shouldShowProjects(projectSelected, pullRequestSelected, projectButtonClicked)'
         },
         projects: {
           type: Array,
@@ -200,16 +194,16 @@
       _isActiveProject: function(name, project, activeProject) {
         return !!name && project === activeProject;
       },
-      _getCurrentView: function(name, pr) {
-        if (!name.name) {
+      _getCurrentView: function(projectSelected, pullRequestSelected) {
+        if (!projectSelected) {
           return 'no-selected';
-        } else if (!pr.pr) {
+        } else if (!pullRequestSelected) {
           return 'overview';
         }
         return 'pr';
       },
-      _shouldShowProjects: function(name, pr, clicked) {
-        return (this._getCurrentView(name, pr) !== 'pr' || clicked) ? 'true' : 'false';
+      _shouldShowProjects: function(projectSelected, pullRequestSelected, clicked) {
+        return (!pullRequestSelected || clicked) ? 'true' : 'false';
       }
     });
   </script>


### PR DESCRIPTION
`carbon-route` has been updated to correctly work with redirects. I changed the property checks to `active` to simplify the logic. Also fixed a bug with the collapse-arrow on the pull-request-list.
