### PR TITLE
Fix the diff parser to handle optional range numbers in the diff hunk

### DIFF
--- a/src/projects/diff/diff.html
+++ b/src/projects/diff/diff.html
@@ -221,7 +221,8 @@
         // [4] - Start line number after the change is applied
         // [5] - Amount of lines after the change is applied
         // [6] = all changes matched by ANTYHING
-        var GROUP_DELIMETER = '@@ \\-(\\d+),(\\d+) \\+(\\d+),(\\d+) @@';
+        var DIGITS = '(\\d+)(?:,(\\d+))?';
+        var GROUP_DELIMETER = '@@ \\-' + DIGITS + ' \\+' + DIGITS + ' @@';
         var GROUP_EXPRESSION = '(' + GROUP_DELIMETER  + ')(' + ANYTHING + ')' + '(?:(?=\n' + GROUP_DELIMETER + ')|$)';
         var GROUP_REGEX = new RegExp(GROUP_EXPRESSION, 'g');
 


### PR DESCRIPTION
Previously, the diff parser would fail when it encounters a hunk like this one:
`@ -0,0 +1 @`

![screenshot from 2016-05-25 15 53 25](https://cloud.githubusercontent.com/assets/5946422/15542404/ea74bc9e-2290-11e6-8a55-1a81855c4a21.png)

The assumption was made that hunks would always contain four numbers. This is not the case however, as documented here: https://www.gnu.org/software/diffutils/manual/diffutils.html#Detailed-Unified
