### PR TITLE
Fix non-derterminism in to-date-string-behavior tests

### DIFF
--- a/src/util/to-date-string-behavior.html
+++ b/src/util/to-date-string-behavior.html
@@ -8,7 +8,7 @@
  */
 ToDateStringBehavior = {
   toDateString: function(text) {
-    var diff = new Date(new Date().getTime() - new Date(text).getTime());
+    var diff = new Date(this._getCurrentTime() - new Date(text).getTime());
     var seconds = Math.ceil(diff / 1000);
     if (seconds < 45) {
       return '<1mi';
@@ -49,6 +49,9 @@ ToDateStringBehavior = {
       return '1y';
     }
     return Math.ceil(days / 365) + 'y';
+  },
+  _getCurrentTime: function() {
+    return new Date().getTime();
   }
 };
 </script>

--- a/test/util/to-date-string-behavior.html
+++ b/test/util/to-date-string-behavior.html
@@ -15,9 +15,13 @@
   <script>
     suite('<to-date-string-behavior>', function() {
       var behavior;
+      // Deterministic point in time
+      // To prevent tests from failing due to timing differences
+      //  when using Date().getTime();
+      var now = 1464342890215;
 
       function ISOtimeAgo(hours) {
-        return new Date(new Date().getTime() - hours * 60 * 60 * 1000).toISOString();
+        return new Date(now - hours * 60 * 60 * 1000).toISOString();
       }
 
       function assertText(hours, expected) {
@@ -27,6 +31,9 @@
 
       setup(function() {
         behavior = ToDateStringBehavior;
+        behavior._getCurrentTime = function() {
+          return now;
+        }
       });
 
       test('shows less than 1 minute when less than 45 seconds ago', function() {


### PR DESCRIPTION
Tests now use one reference time as 'current' time to prevent time from passing during test runs.
