### PR TITLE
Fix tapping on iron-pages to hide the project list

### DIFF
--- a/src/projects/navigation/list-navigation.html
+++ b/src/projects/navigation/list-navigation.html
@@ -149,7 +149,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         nameTail: Object,
         showProjectsList: {
           type: Boolean,
-          value: true,
           notify: true
         },
         showPullList: {

--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -68,7 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
     </style>
     <carbon-route route="{{route}}" pattern="/:owner/:name" data="{{projectTitle}}" tail="{{nameTail}}" active="{{projectSelected}}"></carbon-route>
-    <carbon-route route="[[nameTail]]" pattern="/:subpage" active="{{subPageActive}}"></carbon-route>
+    <carbon-route route="[[nameTail]]" pattern="/:subpage" data="{{subPage}}"></carbon-route>
     <carbon-route route="{{nameTail}}" pattern="/pulls/:pr" data="{{pr}}" tail="{{prTail}}" active="{{pullRequestSelected}}"></carbon-route>
 
     <github-authenticated-ajax
@@ -84,8 +84,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       last-response="{{newPullrequest}}"></github-authenticated-ajax>
 
     <list-navigation
-        route="[[route]]" show-projects-list="[[showProjectsList]]"
-        show-pull-list="[[showPullList]]" selected-pull="[[selectedPull]]"
+        route="[[route]]" show-projects-list="{{showProjectsList}}"
+        show-pull-list="{{showPullList}}" selected-pull="[[selectedPull]]"
         name-tail="{{nameTail}}" project="[[projectTitle]]"
         projects="[[projects]]" pullrequests="[[pullrequests]]"
         on-opened-project="_focusProject"></list-navigation>
@@ -94,7 +94,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         class="project"
         selected="[[_getCurrentView(projectSelected, pullRequestSelected)]]"
         attr-for-selected="data-route"
-        on-tap="_hideProjectList">
+        on-tap="_tapHideProjectList">
       <no-project-selected data-route="no-selected"></no-project-selected>
       <project-overview-page data-route="overview" tabindex="0"
           project="[[activeProject]]" route="{{nameTail}}" pullrequests="[[pullrequests]]"></project-overview-page>
@@ -164,7 +164,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       observers: [
         'chooseProject(projectTitle.*)',
         '_showPullRequest(newPullrequest)',
-        '_hideProjectList(subPageActive)',
+        '_hideProjectList(pullRequestSelected, subPage)',
         '_showPullsList(projectSelected)'
       ],
       listeners: {
@@ -203,8 +203,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
         return 'pr';
       },
-      _hideProjectList: function(subPageActive) {
-        this.showProjectsList = !subPageActive;
+      _tapHideProjectList: function() {
+        this.showProjectsList = !this.projectSelected;
+      },
+      _hideProjectList: function(pullRequestSelected) {
+        this.showProjectsList = !pullRequestSelected;
       },
       _showPullsList: function(projectSelected) {
         this.showPullList = projectSelected;

--- a/test/projects/projects-page.html
+++ b/test/projects/projects-page.html
@@ -51,15 +51,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <script>
     suite('<projects-page>', function() {
-      var projectPage;
+      var projectPage, ironPages;
 
       setup(function() {
         projectPage = fixture('projects-page-fixture');
+        ironPages = Polymer.dom(projectPage.root).querySelector('iron-pages');
       });
 
       test('hide list when a project is clicked', function() {
         projectPage.showProjectsList = true;
-        MockInteractions.tap(Polymer.dom(projectPage.root).querySelector('iron-pages'));
+        projectPage.projectSelected = true;
+        MockInteractions.tap(ironPages);
         assert.isFalse(projectPage.showProjectsList);
       });
 
@@ -70,12 +72,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       });
 
       test('hide project list when pull request is selected', function() {
-        projectPage.subPageActive = true;
+        projectPage.pullRequestSelected = true;
+        projectPage.subPage = {
+          subpage: 'pulls'
+        };
         assert.isFalse(projectPage.showProjectsList);
       });
 
       test('show project list when no pull request is selected', function() {
-        projectPage.subPageActive = false;
+        projectPage.pullRequestSelected = false;
+        projectPage.subPage = {
+          subpage: 'activity'
+        };
         assert.isTrue(projectPage.showProjectsList);
       });
 
@@ -91,18 +99,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
       test('shows no project selected page when no project selected', function() {
         projectPage.projectSelected = false;
-        assert.equal('no-selected', Polymer.dom(projectPage.root).querySelector('iron-pages').selected);
+        assert.equal('no-selected', ironPages.selected);
       });
 
       test('shows overview page when a project is selected', function() {
         projectPage.projectSelected = true;
-        assert.equal('overview', Polymer.dom(projectPage.root).querySelector('iron-pages').selected);
+        assert.equal('overview', ironPages.selected);
       });
 
       test('shows pull request page when a pull request is selected', function() {
         projectPage.projectSelected = true;
         projectPage.pullRequestSelected = true;
-        assert.equal('pr', Polymer.dom(projectPage.root).querySelector('iron-pages').selected);
+        assert.equal('pr', ironPages.selected);
       });
 
       test('shows closed prs when event is fired with closed', function() {


### PR DESCRIPTION
I cry :sob: 

So tapping works again. It now only hides when a pull request was selected.
