### PR TITLE
Fixed the collapsing of hunks

### DIFF
--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -165,7 +165,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           value: ''
         },
         collapseComments: {
-          type: Object,
+          type: Boolean,
           value: true
         },
         hideComments: {

--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -165,7 +165,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           value: ''
         },
         collapseComments: {
-          type: Boolean,
+          type: Object,
           value: true
         },
         hideComments: {
@@ -180,6 +180,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         },
         project: Object
       },
+      observers: ['_resetCollapsed(group)'],
       attached: function() {
         if (!this.editable && !this.description) {
           this.hideDescription = true;
@@ -229,7 +230,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
       _shouldHideComments: function(collapsed, editable) {
         return collapsed || editable;
+      },
+      _resetCollapsed: function() {
+        this.collapsed = false;
+        this.collapseComments = true;
       }
+
     });
   </script>
 </dom-module>

--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -130,7 +130,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         linesChanged: Object
       },
       observers: [
-        '_observeLinesChanged(linesChanged, code)'
+        '_observeLinesChanged(linesChanged, code)',
+        '_resetCollapsed(code)'
       ],
       _observeLinesChanged: function(linesChanged, code) {
         var lines = code.split('\n');
@@ -175,6 +176,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
         var event = this.fire('syntax-highlight', {code: code, lang: 'diff'});
         return event.detail.code || code;
+      },
+      _resetCollapsed(code) {
+        this.collapsed = false;
       }
     });
   </script>

--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <template>
     <style is="custom-style" include="prism-styles"></style>
     <style>
+      [hidden] {
+        display: none !important;
+      }
       :host {
         display: block;
         margin: 1em 0;
@@ -100,7 +103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <a href$="[[fileUrl]]" target="_blank">Full file</a>
       <collapse-icon collapsed="{{collapsed}}"></collapse-icon>
     </header>
-    <div class="content">
+    <div class="content" hidden$="[[collapsed]]">
       <div class="lines">
         <div id="beforeColumn"></div>
         <div id="afterColumn"></div>
@@ -119,7 +122,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           observer: '_render'
         },
         fileUrl: String,
-        collapsed: Boolean,
+        collapsed: {
+          type: Boolean,
+          value: false
+        },
         file: String,
         linesChanged: Object
       },

--- a/test/projects/diff/highlight.html
+++ b/test/projects/diff/highlight.html
@@ -112,6 +112,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           assert.equal(emptyAfterLines.length, afterLines.length);
         });
 
+        test('Hides diff when collapsed', function() {
+            diffElem.collapsed = true;
+            var display = getComputedStyle(get('.content')).display;
+            assert.equal('none', display);
+        });
+
+        test('Shows diff when not collapsed', function() {
+            diffElem.collapsed = false;
+            var display = getComputedStyle(get('.content')).display;
+            assert.notEqual('none', display);
+        });
+
         var getChildrenForId = function(id) {
           return [].slice.call(Polymer.dom(diffElem.root).querySelector('#' + id).children)
         }
@@ -126,6 +138,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           return elems.filter(function(e) {
             return e.innerHTML === '';
           });
+        }
+
+        var get = function(elem) {
+          return Polymer.dom(diffElem.root).querySelector(elem);
         }
       });
     });


### PR DESCRIPTION
Fixed #169 

The state is still shared between childs, but that is the same for the whole group and comments.
This is something that should be fixed, but I believe it's out of scope of this issue.
The issue is reported at the polymer repo, namely 3505.
But the proposed solution does not seem to work.
`When initializing a property to an object or array value, use a function to ensure that each element gets its own copy of the value, rather than having an object or array shared across all instances of the element.`

Edit:
This issue is now fixed by the second commit of this pull request.
The collapsed property is reset on every reload.
