### PR TITLE
Fix empty pseudo selector in create pull view

### DIFF
--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -257,6 +257,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           this.$.hunks.reset(function(hunk) {
             return this._createDraggableGroup(hunk, editable);
           }.bind(this));
+          this.async(function() {
+            // Force a recalc to make sure that the `:empty` pseudo selector
+            // is correctly cleared after stamping groups to the hunks section
+            this.$.hunks.style.zoom = this.$.hunks.style.zoom ? '0.999999' : '1';
+          }, 1);
         }
       },
       _createDraggableGroup: function(hunk, editable) {


### PR DESCRIPTION
By forcing a recalculation, we somehow trigger the `:empty` selector to be cleared.

Fixes #215
