### PR TITLE
Update to newest version of prism-element and prism

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,13 +23,14 @@
     "iron-lazy-pages": "^1.0.2",
     "Sortable": "TimvdLippe/Sortable#fix-es5-compilation",
     "marked-element": "TimvdLippe/marked-element#expose-callback",
-    "prism-element": "TimvdLippe/prism-element#prism-css-module",
-    "polymerfire": "firebase/polymerfire#^0.9.2"
+    "prism-element": "polymerelements/prism-element#master",
+    "polymerfire": "firebase/polymerfire#^0.9.2",
+    "prism": "1.5.1"
   },
   "resolutions": {
     "carbon-route": "reset-tail",
     "marked-element": "expose-callback",
-    "prism-element": "prism-css-module"
+    "prism-element": "master"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -28,12 +28,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../util/collapse-icon.html">
-<link rel="import" href="../../bower_components/prism-element/prism-style-import.html">
+<link rel="import" href="../../bower_components/prism-element/prism-theme-default.html">
 <link rel="import" href="hunk-ghost.html">
 
 <dom-module id='pull-request-diff-highlight'>
   <template>
-    <style is="custom-style" include="prism-styles"></style>
+    <style is="custom-style" include="prism-theme-default"></style>
     <style>
       [hidden] {
         display: none !important;

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html">
 <link rel="import" href="bower_components/prism-element/prism-highlighter.html">
-<link rel="import" href="bower_components/prism-element/prism-style-import.html">
 
 <link rel="stylesheet" href="bower_components/font-roboto/roboto.html">
 <link rel="import" href="ajax/github-authenticated-ajax.html">
@@ -49,9 +48,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*global Prism*/
 // Match all lines that are not insertions or deletions
 Prism.languages.diff.other = /.+/m;
-// Additions and deletions can also be an empty line
-Prism.languages.diff.inserted = /^[+>].*$/m
-Prism.languages.diff.deleted = /^[-<].*$/m
 </script>
 
 <dom-module id="rite-app">


### PR DESCRIPTION
This updates the dependencies to not fail on installation. Also updated to the newest versions to integrate latest changes. Run `bower update` to fetch the latest versions.

See https://github.com/PrismJS/prism/pull/952
See https://github.com/PolymerElements/prism-element/pull/17

Fixes #57 
Fixes #227 
