### PR TITLE
Wire ordering

### DIFF
--- a/src/projects/diff/diff.html
+++ b/src/projects/diff/diff.html
@@ -152,7 +152,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         'order': '_groupMove',
         'remove': '_hunkRemoved',
         'add': '_hunkAdded',
-        'update': '_hunkUpdate'
+        'update': '_hunkUpdate',
+        'orderUpdate': '_updateUI'
       },
       _openAddGroupDialog: function() {
         this.$.addGroupDialog.open();
@@ -185,6 +186,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
       _groupMove: function(e) {
         this.$.sorter.moveGroup(e.detail.oldIndex, e.detail.newIndex);
+      },
+      _updateUI: function() {
         var groups = this.orderedGroups;
         this.set('orderedGroups', []);
         this.set('orderedGroups', groups);

--- a/src/projects/diff/diff.html
+++ b/src/projects/diff/diff.html
@@ -107,7 +107,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <order-dialog
       id="orderGroupDialog"
       action-title="Drag groups to re-order them"
-      on-confirm="_reorderGroups"
       items="[[_groupTitles]]"
     ></order-dialog>
 
@@ -166,9 +165,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           return group.title;
         });
       },
-      _reorderGroups: function() {
-        // console.log('reorder plz');
-      },
       jumpToGroup: function(name) {
         var group = this.$$('pull-request-group[display-title="' + name + '"]');
         this.fire('scroll-to', {
@@ -179,19 +175,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         this.$.sorter.addGroup(e.detail);
       },
       _hunkAdded: function(e) {
-        console.log('added group', e.detail);
+        this.$.sorter.addHunkToGroup(e.detail.hunk, e.detail.groupId, e.detail.newIndex);
       },
       _hunkRemoved: function(e) {
-        console.log('removed group', e.detail);
+        this.$.sorter.removeHunkFromGroup(e.detail.groupId, e.detail.hunk);
       },
       _hunkUpdate: function(e) {
-        console.log('updated group', e.detail);
-      },
-      _groupEmpty: function(e) {
-        console.log('group is now empty', e.detail.groupName);
+        this.$.sorter.moveHunk(e.detail.groupId, e.detail.oldIndex, e.detail.newIndex);
       },
       _groupMove: function(e) {
-        console.log('moved group', e);
+        this.$.sorter.moveGroup(e.detail.oldIndex, e.detail.newIndex);
+        var groups = this.orderedGroups;
+        this.set('orderedGroups', []);
+        this.set('orderedGroups', groups);
       }
     });
   </script>

--- a/src/projects/diff/diff.html
+++ b/src/projects/diff/diff.html
@@ -91,11 +91,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
     </style>
     <diff-parser diff="[[diff]]" base-url="[[baseUrl]]" sha="[[sha]]" additions="{{additions}}" deletions="{{deletions}}" hunks="{{hunks}}"></diff-parser>
-    <hunk-sorter id="sorter" raw-hunks="[[hunks]]" groups="{{orderedGroups}}"></hunk-sorter>
+    <hunk-sorter id="sorter" raw-hunks="[[hunks]]" groups="{{orderedGroups}}" project="[[project]]"></hunk-sorter>
 
     <div id="hunkGroups">
       <template is="dom-repeat" items="[[orderedGroups]]">
-        <pull-request-group group="[[item]]" editable="[[editable]]"></pull-request-group>
+        <pull-request-group group="[[item]]" editable="[[editable]]" project="[[project]]"></pull-request-group>
       </template>
     </div>
 
@@ -123,6 +123,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'pull-request-diff',
       properties: {
+        project: Object,
         editable: {
           type: Boolean,
           value: false
@@ -146,12 +147,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         _sortable: Object
       },
       observers: [
-        '_groupsOrdered(orderedGroups.*, editable)',
         '_setGroupTitles(orderedGroups.*)'
       ],
       listeners: {
-        'empty': '_groupEmpty',
-        'order': '_groupMove'
+        'order': '_groupMove',
+        'remove': '_hunkRemoved',
+        'add': '_hunkAdded',
+        'update': '_hunkUpdate'
       },
       _openAddGroupDialog: function() {
         this.$.addGroupDialog.open();
@@ -167,16 +169,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       _reorderGroups: function() {
         // console.log('reorder plz');
       },
-      _groupsOrdered: function(orderedGroups, editable) {
-        var groups = orderedGroups.base;
-        if (editable && !this._sortable &&
-            groups && groups[0].diff.length > 0) {
-          this._sortable = true;
-          this.$.hunkGroups.addEventListener('add', this._groupAdded.bind(this));
-          this.$.hunkGroups.addEventListener('remove', this._groupRemoved.bind(this));
-          this.$.hunkGroups.addEventListener('update', this._groupUpdate.bind(this));
-        }
-      },
       jumpToGroup: function(name) {
         var group = this.$$('pull-request-group[display-title="' + name + '"]');
         this.fire('scroll-to', {
@@ -186,20 +178,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       _addGroup: function(e) {
         this.$.sorter.addGroup(e.detail);
       },
-      _groupAdded: function(e) {
-        // console.log('added group', e);
+      _hunkAdded: function(e) {
+        console.log('added group', e.detail);
       },
-      _groupRemoved: function(e) {
-        // console.log('removed group', e);
+      _hunkRemoved: function(e) {
+        console.log('removed group', e.detail);
       },
-      _groupUpdate: function(e) {
-        // console.log('updated group', e);
+      _hunkUpdate: function(e) {
+        console.log('updated group', e.detail);
       },
       _groupEmpty: function(e) {
-        // console.log('group is now empty', e.detail.groupName);
+        console.log('group is now empty', e.detail.groupName);
       },
       _groupMove: function(e) {
-        // console.log('moved group', e);
+        console.log('moved group', e);
       }
     });
   </script>

--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -291,7 +291,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           e.stopPropagation();
           this.fire(name, {
             hunk: e.item.children[1].hunk,
-            group: this.group.title,
+            groupId: this.group.id,
             oldIndex: e.oldIndex,
             newIndex: e.newIndex
           });

--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -247,12 +247,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               dataTransfer.setDragImage(dragEl.querySelector('pull-request-diff-highlight').hunk.img, 50, 50);
             }
           });
-          this.$.hunks.addEventListener('remove', this._hunkRemoved.bind(this));
+          this.$.hunks.addEventListener('remove', this._fire('remove').bind(this));
+          this.$.hunks.addEventListener('add', this._fire('add').bind(this));
+          this.$.hunks.addEventListener('update', this._fire('update').bind(this));
           this._isAlreadyInitialized = true;
           this.updateStyles();
         }
       },
       _groupChanged: function(group, editable) {
+        console.log(group);
         if (group) {
           this.$.hunks.reset(function(hunk) {
             return this._createDraggableGroup(hunk, editable);
@@ -284,9 +287,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
         return group.title;
       },
-      _hunkRemoved: function() {
-        if (this.group.diff.length === 0) {
-          this.fire('empty', {groupName: this.group.title});
+      _fire: function(name) {
+        return function(e) {
+          e.stopPropagation();
+          this.fire(name, {
+            hunk: e.item.children[1].hunk,
+            group: this.group.title,
+            oldIndex: e.oldIndex,
+            newIndex: e.newIndex
+          });
         }
       },
       _shouldHideComments: function(collapsed, editable) {

--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -255,7 +255,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
       },
       _groupChanged: function(group, editable) {
-        console.log(group);
         if (group) {
           this.$.hunks.reset(function(hunk) {
             return this._createDraggableGroup(hunk, editable);

--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -171,7 +171,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         var event = this.fire('syntax-highlight', {code: code, lang: 'diff'});
         return event.detail.code || code;
       },
-      _resetCollapsed(code) {
+      _resetCollapsed: function(code) {
         this.collapsed = false;
       }
     });

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -65,22 +65,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
         }
       },
+
       addGroup: function(groupTitle) {
-        if (!this._hasGroup(groupTitle)) {
+        if (!this._groupTitleExists(groupTitle)) {
           this.unshift('_ordering', this._createHunkOrdering(groupTitle, []));
         }
       },
-      removeGroup: function(groupTitle) {
-        if (groupTitle !== 'Unsorted changes' &&
-            this._hasGroup(groupTitle)) {
+
+      removeGroup: function(groupId) {
+        if (groupId !== 1 &&
+            this._groupExists(groupId)) {
           this._ordering = this._ordering.filter(function(o) {
-            return o.title !== groupTitle;
+            return o.id !== groupId;
           });
         }
       },
+
       addHunkToGroup: function(hunkId, groupTitle, index) {
 
       },
+
       removeHunkFromGroup: function(hunkId, groupTitle) {
         for (var i = 0, l = this._ordering.length; i < l; i++) {
           for (j = 0, m = group.length; j < m; j++) {
@@ -89,6 +93,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
         }
       },
+
       moveHunk: function(hunkId, oldIndex, newIndex) {
 
       },
@@ -114,14 +119,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
         }
 
-        var unsortedGroup = this._createGroup('Unsorted changes', []);
-        var remainingHunk, i = 0;
-        for (var remainingHunkId in unsortedHunks) {
-          remainingHunk = unsortedHunks[remainingHunkId];
-          remainingHunk.order = i++;
-          unsortedGroup.diff.push(remainingHunk);
-        }
-        allGroups.push(unsortedGroup);
+        allGroups.push(this._distributeUnsortedHunks(unsortedHunks));
         return allGroups;
       },
 
@@ -138,7 +136,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         hunks = hunks.filter(function(hunk) {
           return !!hunk;
         });
-        return this._createGroup(hunkOrdering.title, hunks);
+        return this._createGroup(hunkOrdering.title, hunkOrdering.id, hunks);
       },
 
       _findHunksInOrdering: function(hunkOrdering, unsortedHunks) {
@@ -156,6 +154,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }.bind(this));
       },
 
+      _distributeUnsortedHunks: function(unsortedHunks) {
+        var unsortedGroup = this._createDefaultGroup();
+        var remainingHunk;
+        for (var remainingHunkId in unsortedHunks) {
+          remainingHunk = unsortedHunks[remainingHunkId];
+          unsortedGroup.diff.push(remainingHunk);
+        }
+        return unsortedGroup;
+      },
+
       _getHunkId: function(hunk) {
         return hunk.file + ',' +
           hunk.linesChanged.startLineBefore + ',' +
@@ -164,26 +172,53 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           hunk.linesChanged.rangeAfter;
       },
 
-      _createGroup: function(title, diff) {
+      _createGroup: function(title, id, diff) {
         return {
+          id: id,
           title: title,
           diff: diff,
           comments: []
         }
       },
 
+      _createDefaultGroup: function() {
+        return this._createGroup('Unsorted changes', 1, []);
+      },
+
       _createHunkOrdering: function(title, hunkIds) {
         return {
+          id: this.guid(),
           title: title,
           hunks: hunkIds
         }
       },
 
-      _hasGroup: function(title) {
-        return this.groups.filter(function(g) {
-          return g.title === title;
-        }).length > 0;
+      _groupExists: function(id) {
+        return this._searchGroup('id').bind(this)(id);
+      },
+
+      _groupTitleExists: function(title) {
+        return this._searchGroup('title').bind(this)(title);
+      },
+
+      _searchGroup: function(field) {
+        return function(entry) {
+          return this.groups.filter(function(g) {
+            return g[field] === entry;
+          }).length > 0;
+        }
+      },
+
+      /**
+       * RFC4122 v4 compliant GUID generator
+       */
+      guid: function() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+            return v.toString(16);
+        });
       }
+
     });
   </script>
 </dom-module>

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -26,6 +26,8 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
 <dom-module id="hunk-sorter">
   <template>
     <!--
@@ -41,51 +43,47 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'hunk-sorter',
       properties: {
+
         rawHunks: {
-          type: Array,
-          value: []
-        },
-        ordering: {
           type: Array,
           value: []
         },
         groups: {
           type: Array,
           value: [],
-          computed: '_sortHunks(_unsortedHunkMap, _groupMap)',
+          computed: '_sortHunks(rawHunks, _ordering.*)',
           notify: true
         },
-        _unsortedHunkMap: {
-          type: Object,
-          computed: '_onNewHunks(rawHunks)'
-        },
-        _groupMap: {
-          type: Object,
-          // Temp solution until firebase gets wired up
+        _ordering: {
+          type: Array,
           value: function() {
-            return {
-              'Amazing stuff': {
-                order: 0,
-                hunks: ['src/lib/base.html,138,9,139,9'],
-                comments: []
-              }
-            };
+            return [];
           }
         }
       },
       addGroup: function(groupTitle) {
-        this.unshift('groups', this._createGroup(groupTitle, []));
+        if (!this._hasGroup(groupTitle)) {
+          this.unshift('_ordering', this._createHunkOrdering(groupTitle, []));
+        }
       },
       removeGroup: function(groupTitle) {
-        if (groupTitle !== 'Unsorted changes') {
-          delete this._groupMap[groupTitle];
+        if (groupTitle !== 'Unsorted changes' &&
+            this._hasGroup(groupTitle)) {
+          this._ordering = this._ordering.filter(function(o) {
+            return o.title !== groupTitle;
+          });
         }
       },
       addHunkToGroup: function(hunkId, groupTitle, index) {
 
       },
       removeHunkFromGroup: function(hunkId, groupTitle) {
+        for (var i = 0, l = this._ordering.length; i < l; i++) {
+          for (j = 0, m = group.length; j < m; j++) {
+            var hunkId = group[j];
 
+          }
+        }
       },
       moveHunk: function(hunkId, oldIndex, newIndex) {
 
@@ -93,21 +91,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       moveGroup: function(groupTitle, oldIndex, newIndex) {
 
       },
-      _onNewHunks: function(hunks) {
-        var allHunks = {};
-        hunks.forEach(function(hunk) {
-          allHunks[this._getHunkId(hunk)] = hunk;
-        }.bind(this));
-        return allHunks;
-      },
-      _sortHunks: function(unsortedHunks, groupMap) {
-        if (unsortedHunks.size === 0) {
-          return;
+
+
+      _sortHunks: function(rawHunks, o) {
+        if (o.path === '_ordering.length') {
+          return this.groups;
         }
+        var ordering = o.base;
+        var unsortedHunks = this._hunksToMap(rawHunks);
+
         var allGroups = [];
         var group;
-        for (var title in groupMap) {
-          group = this._reconstructGroup(groupMap[title], unsortedHunks);
+        for (var i = 0, l = ordering.length; i < l; i++) {
+          var group = this._reconstructGroup(ordering[i], unsortedHunks);
           if (group) {
             allGroups.push(group);
           }
@@ -123,17 +119,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         allGroups.push(unsortedGroup);
         return allGroups;
       },
-      _reconstructGroup: function(group, unsortedHunks) {
-        var hunks = this._findHunksInGroup(group, unsortedHunks);
+
+      _hunksToMap: function(hunks) {
+        var allHunks = {};
+        hunks.forEach(function(hunk) {
+          allHunks[this._getHunkId(hunk)] = hunk;
+        }.bind(this));
+        return allHunks;
+      },
+
+      _reconstructGroup: function(hunkOrdering, unsortedHunks) {
+        var hunks = this._findHunksInOrdering(hunkOrdering, unsortedHunks);
         hunks = hunks.filter(function(hunk) {
           return !!hunk;
         });
-        if (hunks.length > 0) {
-          return this._createGroup(group.title, hunks);
-        }
+        return this._createGroup(hunkOrdering.title, hunks);
       },
-      _findHunksInGroup: function(group, unsortedHunks) {
-        return group.hunks.map(function(hunkId) {
+
+      _findHunksInOrdering: function(hunkOrdering, unsortedHunks) {
+        if (hunkOrdering.length === 0) {
+          return;
+        }
+        return hunkOrdering.hunks.map(function(hunkId) {
           var hunk = unsortedHunks[hunkId];
           delete unsortedHunks[hunkId];
           if (hunk) {
@@ -143,6 +150,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
         }.bind(this));
       },
+
       _getHunkId: function(hunk) {
         return hunk.file + ',' +
           hunk.linesChanged.startLineBefore + ',' +
@@ -150,12 +158,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           hunk.linesChanged.startLineAfter + ',' +
           hunk.linesChanged.rangeAfter;
       },
+
       _createGroup: function(title, diff) {
         return {
           title: title,
           diff: diff,
           comments: []
         }
+      },
+
+      _createHunkOrdering: function(title, hunkIds) {
+        return {
+          title: title,
+          hunks: hunkIds
+        }
+      },
+
+      _hasGroup: function(title) {
+        return this.groups.filter(function(g) {
+          return g.title === title;
+        }).length > 0;
       }
     });
   </script>

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -109,6 +109,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         if (this.groups[index].diff.length === 0) {
           this.groups.splice(index, 1);
           this._ordering.splice(index, 1);
+          this.fire('orderUpdate');
         }
       },
 
@@ -137,6 +138,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           var ord = this._ordering.splice(oldIndex, 1)[0];
           this.groups.splice(Math.max(newIndex, 0), 0, group);
           this._ordering.splice(Math.max(newIndex, 0), 0, ord);
+          this.fire('orderUpdate');
         }
       },
 

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -112,7 +112,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
       },
 
-      _doForGroup(groupId, f) {
+      _doForGroup: function(groupId, f) {
         for (var i = 0, l = this._ordering.length; i < l; i++) {
           if (this._ordering[i].id === groupId) {
             return f(i, this.groups[i], this._ordering[i]);
@@ -140,7 +140,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
       },
 
-      _getOrderingFromFirebaseObj(fbOrdering) {
+      _getOrderingFromFirebaseObj: function(fbOrdering) {
         var defaultGroupName = 'Unsorted changes';
         var ordering = [];
         if (fbOrdering.ordering) {
@@ -211,9 +211,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
 
       _getHunkId: function(hunk) {
-        if (!hunk) {
-          return;
-        }
         return hunk.file + ',' +
           hunk.linesChanged.startLineBefore + ',' +
           hunk.linesChanged.rangeBefore + ',' +
@@ -240,10 +237,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
       _groupExists: function(id) {
         return this._searchGroup('id').bind(this)(id);
-      },
-
-      _groupTitleExists: function(title) {
-        return this._searchGroup('title').bind(this)(title);
       },
 
       _searchGroup: function(field) {

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -43,19 +43,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'hunk-sorter',
       properties: {
-
-        rawHunks: {
-          type: Array,
-          value: function() {
-            return [];
-          }
-        },
+        rawHunks: Array,
         groups: {
           type: Array,
           value: function() {
             return [];
           },
-          computed: '_sortHunks(rawHunks, _ordering.*)',
           notify: true
         },
         _ordering: {
@@ -63,64 +56,118 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           value: function() {
             return [];
           }
-        }
+        },
+        _remoteOrdering: Object
+      },
+      observers: [
+        '_sortHunks(rawHunks, _remoteOrdering)'
+      ],
+      attached: function() {
+        // Remove when linking to Firebase
+        this._remoteOrdering = [];
       },
 
       addGroup: function(groupTitle) {
-        if (!this._groupTitleExists(groupTitle)) {
-          this.unshift('_ordering', this._createHunkOrdering(groupTitle, []));
-        }
+        var group = this._createHunkOrdering(groupTitle, []);
+        this.unshift('_ordering', group);
+        this.unshift('groups', this._createGroup(groupTitle, group.id, []));
+        return group.id;
       },
 
       removeGroup: function(groupId) {
-        if (groupId !== 1 &&
-            this._groupExists(groupId)) {
+        if (this._groupExists(groupId)) {
           this._ordering = this._ordering.filter(function(o) {
             return o.id !== groupId;
+          });
+          this.groups = this.groups.filter(function(g) {
+            return g.id !== groupId;
+          })
+        }
+      },
+
+      addHunkToGroup: function(hunk, groupId, index) {
+        this._doForGroup(groupId, function(i, group, groupOrdering) {
+          group.diff.splice(index, 0, hunk);
+          groupOrdering.hunks.splice(index, 0, this._getHunkId(hunk));
+        }.bind(this));
+      },
+
+      removeHunkFromGroup: function(groupId, hunk) {
+        this._doForGroup(groupId, function(i, group, groupOrdering) {
+          for (var j = 0, m = groupOrdering.hunks.length; j < m; j++) {
+            if (this._getHunkId(hunk) === groupOrdering.hunks[j]) {
+              groupOrdering.hunks.splice(j, 1);
+              this.groups[i].diff.splice(j, 1);
+              this._removeGroupIfEmpty(i);
+              return;
+            }
+          }
+        }.bind(this));
+      },
+
+      _removeGroupIfEmpty: function(index) {
+        if (this.groups[index].diff.length === 0) {
+          this.groups.splice(index, 1);
+          this._ordering.splice(index, 1);
+        }
+      },
+
+      _doForGroup(groupId, f) {
+        for (var i = 0, l = this._ordering.length; i < l; i++) {
+          if (this._ordering[i].id === groupId) {
+            return f(i, this.groups[i], this._ordering[i]);
+          }
+        }
+      },
+
+      moveHunk: function(groupId, oldIndex, newIndex) {
+        if (oldIndex !== newIndex) {
+          this._doForGroup(groupId, function(index, group, groupOrdering) {
+            var hunk = group.diff.splice(oldIndex, 1)[0];
+            var hunkId = groupOrdering.hunks.splice(oldIndex, 1)[0];
+            group.diff.splice(Math.max(newIndex, 0), 0, hunk);
+            groupOrdering.hunks.splice(Math.max(newIndex, 0), 0, hunkId);
           });
         }
       },
 
-      addHunkToGroup: function(hunkId, groupTitle, index) {
-
-      },
-
-      removeHunkFromGroup: function(hunkId, groupTitle) {
-        for (var i = 0, l = this._ordering.length; i < l; i++) {
-          for (j = 0, m = group.length; j < m; j++) {
-            var hunkId = group[j];
-
-          }
+      moveGroup: function(oldIndex, newIndex) {
+        if (oldIndex !== newIndex) {
+          var group = this.groups.splice(oldIndex, 1)[0];
+          var ord = this._ordering.splice(oldIndex, 1)[0];
+          this.groups.splice(Math.max(newIndex, 0), 0, group);
+          this._ordering.splice(Math.max(newIndex, 0), 0, ord);
         }
       },
 
-      moveHunk: function(hunkId, oldIndex, newIndex) {
-
-      },
-      moveGroup: function(groupTitle, oldIndex, newIndex) {
-
-      },
-
-
-      _sortHunks: function(rawHunks, o) {
-        if (o.path === '_ordering.length') {
-          return this.groups;
+      _getOrderingFromFirebaseObj(fbOrdering) {
+        var defaultGroupName = 'Unsorted changes';
+        var ordering = [];
+        if (fbOrdering.ordering) {
+          defaultGroupName = 'New changes since: ' + fbOrdering.lastChanged;
+          ordering = fbOrdering.ordering;
         }
-        var ordering = o.base;
-        delete ordering.splices;
+        var defaultGroup = this._createHunkOrdering(defaultGroupName, []);
+        ordering.push(defaultGroup);
+        return [ordering, defaultGroup];
+      },
+
+      _sortHunks: function(rawHunks, fbOrdering) {
+        var tuple = this._getOrderingFromFirebaseObj(fbOrdering);
+        var ordering = tuple[0];
+        var defaultGroup = tuple[1];
         var unsortedHunks = this._hunksToMap(rawHunks);
 
         var allGroups = [];
-        var group;
         for (var i = 0, l = ordering.length; i < l; i++) {
           var group = this._reconstructGroup(ordering[i], unsortedHunks);
-          if (group) {
+          if (group && group.id !== defaultGroup.id) {
             allGroups.push(group);
           }
         }
-
-        allGroups.push(this._distributeUnsortedHunks(unsortedHunks));
-        return allGroups;
+        allGroups.push(this._distributeUnsortedHunks(defaultGroup, unsortedHunks));
+        this.groups = allGroups;
+        this._ordering = ordering;
       },
 
       _hunksToMap: function(hunks) {
@@ -154,17 +201,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }.bind(this));
       },
 
-      _distributeUnsortedHunks: function(unsortedHunks) {
-        var unsortedGroup = this._createDefaultGroup();
-        var remainingHunk;
+      _distributeUnsortedHunks: function(defaultGroup, unsortedHunks) {
+        var unsortedGroup = this._createGroup(defaultGroup.title, defaultGroup.id, []);
         for (var remainingHunkId in unsortedHunks) {
-          remainingHunk = unsortedHunks[remainingHunkId];
-          unsortedGroup.diff.push(remainingHunk);
+          unsortedGroup.diff.push(unsortedHunks[remainingHunkId]);
+          defaultGroup.hunks.push(remainingHunkId);
         }
         return unsortedGroup;
       },
 
       _getHunkId: function(hunk) {
+        if (!hunk) {
+          return;
+        }
         return hunk.file + ',' +
           hunk.linesChanged.startLineBefore + ',' +
           hunk.linesChanged.rangeBefore + ',' +
@@ -181,13 +230,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         }
       },
 
-      _createDefaultGroup: function() {
-        return this._createGroup('Unsorted changes', 1, []);
-      },
-
       _createHunkOrdering: function(title, hunkIds) {
         return {
-          id: this.guid(),
+          id: this._guid(),
           title: title,
           hunks: hunkIds
         }
@@ -203,7 +248,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
       _searchGroup: function(field) {
         return function(entry) {
-          return this.groups.filter(function(g) {
+          return this._ordering.filter(function(g) {
             return g[field] === entry;
           }).length > 0;
         }
@@ -212,9 +257,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       /**
        * RFC4122 v4 compliant GUID generator
        */
-      guid: function() {
+      _guid: function() {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+            var r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
             return v.toString(16);
         });
       }

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -46,11 +46,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
         rawHunks: {
           type: Array,
-          value: []
+          value: function() {
+            return [];
+          }
         },
         groups: {
           type: Array,
-          value: [],
+          value: function() {
+            return [];
+          },
           computed: '_sortHunks(rawHunks, _ordering.*)',
           notify: true
         },
@@ -98,6 +102,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           return this.groups;
         }
         var ordering = o.base;
+        delete ordering.splices;
         var unsortedHunks = this._hunksToMap(rawHunks);
 
         var allGroups = [];
@@ -138,7 +143,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
       _findHunksInOrdering: function(hunkOrdering, unsortedHunks) {
         if (hunkOrdering.length === 0) {
-          return;
+          return [];
         }
         return hunkOrdering.hunks.map(function(hunkId) {
           var hunk = unsortedHunks[hunkId];

--- a/src/projects/diff/order-dialog.html
+++ b/src/projects/diff/order-dialog.html
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/neon-animation/neon-animations.html">
+<link rel="import" href="../../util/dom-repeat-once.html">
 
 <dom-module id="order-dialog">
   <template>
@@ -77,11 +78,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </style>
     <paper-dialog id="dialog" entry-animation="scale-up-animation" exit-animation="fade-out-animation" with-backdrop>
       <h1 id="title">[[actionTitle]]</h1>
-      <div id="sortable">
-        <template is="dom-repeat" items="[[items]]">
-          <div class="item"><iron-icon icon="editor:drag-handle"></iron-icon>[[item]]</div>
-        </template>
-      </div>
+      <dom-repeat-once id="sortable" items="[[items]]">
+      </dom-repeat-once>
       <div class="buttons">
         <paper-button autofocus dialog-dismiss>OK</paper-button>
       </div>
@@ -109,6 +107,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         this.fire('order', {oldIndex: e.oldIndex, newIndex: e.newIndex});
       },
       open: function() {
+        this.$.sortable.reset(function(groupTitle) {
+          var div = document.createElement('div');
+          div.setAttribute('class', 'item');
+          div.innerHTML = '<iron-icon icon="editor:drag-handle"></iron-icon>' + groupTitle;
+          return div;
+        });
         this.$.dialog.open();
       },
       _setDragImage: function(dataTransfer) {

--- a/src/projects/info-header.html
+++ b/src/projects/info-header.html
@@ -26,7 +26,6 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<link rel="import" href="../../bower_components/iron-resizable-behavior/iron-resizable-behavior.html">
 
 <dom-module id="info-header">
   <template>

--- a/src/projects/pull-request/pull-request-changes.html
+++ b/src/projects/pull-request/pull-request-changes.html
@@ -67,13 +67,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         groups="[[orderedGroups]]" hidden$="[[!showSpace]]"></pull-request-space>
     <pull-request-diff id="diff" data-route="diff" diff="[[diff]]"
         ordering="[[ordering]]" ordered-groups="{{orderedGroups}}"
-        base-url="[[baseUrl]]" sha="[[sha]]"></pull-request-diff>
+        base-url="[[baseUrl]]" sha="[[sha]]" project="[[project]]"></pull-request-diff>
 
   </template>
   <script>
     Polymer({
       is: 'pull-request-changes',
       properties: {
+        project: Object,
         diff: String,
         ordering: Array,
         baseUrl: String,

--- a/src/projects/pull-request/pull-request-page.html
+++ b/src/projects/pull-request/pull-request-page.html
@@ -158,8 +158,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         pull-request="[[selectedPull]]" project="[[project]]"></pull-request-general-information>
       <pull-request-commits data-route="commits" pull-request="[[selectedPull]]" project="[[project]]"></pull-request-commits>
       <pull-request-changes data-route="diff" diff="[[diff]]" ordering="[[ordering]]"
-          base-url="[[selectedPull.head.repo.html_url]]"
-          sha="[[selectedPull.head.sha]]" show-space="[[_showSpace]]"></pull-request-changes>
+          base-url="[[selectedPull.head.repo.html_url]]" project="[[project]]"
+          sha="[[selectedPull.head.sha]]"></pull-request-changes>
+
+      <span data-route="404">
+        Oops you hit a 404!
+        <a href="/">Head back home</a>
+      </span>
     </iron-pages>
   </template>
   <script>

--- a/src/projects/pull-request/pull-request-page.html
+++ b/src/projects/pull-request/pull-request-page.html
@@ -158,7 +158,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         pull-request="[[selectedPull]]" project="[[project]]"></pull-request-general-information>
       <pull-request-commits data-route="commits" pull-request="[[selectedPull]]" project="[[project]]"></pull-request-commits>
       <pull-request-changes data-route="diff" diff="[[diff]]" ordering="[[ordering]]"
-          base-url="[[selectedPull.head.repo.html_url]]" project="[[project]]"
+          base-url="[[selectedPull.head.repo.html_url]]" project="[[project]]" show-space="[[_showSpace]]"
           sha="[[selectedPull.head.sha]]"></pull-request-changes>
 
       <span data-route="404">
@@ -187,7 +187,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           computed: '_getShowSpace(page.page)'
         },
         _selectedTab: {
-          type: Boolean,
+          type: String,
           computed: '_getSelectedTab(page.page)'
         }
       },

--- a/src/util/dom-repeat-once.html
+++ b/src/util/dom-repeat-once.html
@@ -13,20 +13,23 @@
     Polymer({
       is: 'dom-repeat-once',
       properties: {
-        items: Array
+        items: {
+          type: Array,
+          value: function() {
+            return [];
+          }
+        }
       },
       reset: function(getItemElem) {
-        if (this.items && this.items.length > 0) {
-          this.items.sort(function(a, b) {
-              if(!b.order || a.order < b.order) return -1;
-              if(!a.order || a.order > b.order) return 1;
-              return 0;
-          });
+        this.items.sort(function(a, b) {
+            if(!b.order || a.order < b.order) return -1;
+            if(!a.order || a.order > b.order) return 1;
+            return 0;
+        });
 
-          this.innerHTML = '';
-          for (var i = 0, l = this.items.length; i < l; i++) {
-            this.appendChild(getItemElem(this.items[i]));
-          }
+        this.innerHTML = '';
+        for (var i = 0, l = this.items.length; i < l; i++) {
+          this.appendChild(getItemElem(this.items[i]));
         }
       }
     });

--- a/test/index.html
+++ b/test/index.html
@@ -57,6 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'projects/diff/group.html?dom=shadow',
         'projects/diff/highlight.html',
         'projects/diff/highlight.html?dom=shadow',
+        'projects/diff/hunk-sorter.html',
         'projects/diff/input-dialog.html',
         'projects/diff/order-dialog.html',
         'projects/navigation/list-navigation.html',

--- a/test/projects/diff/group.html
+++ b/test/projects/diff/group.html
@@ -112,19 +112,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       assert.equal(title.innerHTML, 'someTitle');
     });
 
-    test('fires `empty` event when all diffs are removed', function(done) {
-      groupElem.group = {
-        diff: [],
-        comments: []
-      };
-
-      addEventListener(groupElem, 'empty', function() {
-        done();
-      });
-      groupElem._hunkRemoved();
-    });
-
-
     var addEventListener = function(element, name, func) {
       var inner = function(e) {
         func(e);

--- a/test/projects/diff/group.html
+++ b/test/projects/diff/group.html
@@ -112,14 +112,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       assert.equal(title.innerHTML, 'someTitle');
     });
 
-    var addEventListener = function(element, name, func) {
-      var inner = function(e) {
-        func(e);
-        element.removeEventListener(name, inner);
-      };
-      element.addEventListener(name, inner);
-    }
-
     var get = function(elem) {
       return Polymer.dom(groupElem.root).querySelector(elem);
     }

--- a/test/projects/diff/hunk-sorter.html
+++ b/test/projects/diff/hunk-sorter.html
@@ -85,9 +85,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       assert.equal(2, sorter.groups.length);
     });
 
-    test('removes group by title', function() {
-      sorter.addGroup('01');
-      sorter.removeGroup('01');
+    test('removes group by id', function() {
+      sorter.addGroup('group');
+      var id = sorter.groups[0].id;
+      sorter.removeGroup(id);
       assert.equal(1, sorter.groups.length);
     });
 
@@ -95,8 +96,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       sorter.addGroup('01');
       sorter.addGroup('02');
       sorter.addGroup('03');
-      sorter.removeGroup('01');
+      sorter.removeGroup(sorter.groups[0].id);
       assert.equal(3, sorter.groups.length);
+    });
+
+    test('can remove middle group', function() {
+      sorter.addGroup('01');
+      sorter.addGroup('02');
+      sorter.addGroup('03');
+      sorter.removeGroup(sorter.groups[1].id);
+      assert.equal('01', sorter.groups[1].title);
     });
 
     test('adds hunk to correct group', function() {

--- a/test/projects/diff/hunk-sorter.html
+++ b/test/projects/diff/hunk-sorter.html
@@ -1,0 +1,114 @@
+<!-- Copyright (c) 2016, preview-code
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of rite-evaluation nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<!doctype html>
+<html>
+<head>
+  <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+  <title>hunk-sorter tests</title>
+
+  <script src='../../../src/bower_components/webcomponentsjs/webcomponents-lite.min.js'></script>
+  <script src='../../../src/bower_components/web-component-tester/browser.js'></script>
+  <script src='test-diffs.js'></script>
+
+  <!-- Import the element to test -->
+  <link rel='import' href='../../../src/projects/diff/hunk-sorter.html'>
+
+</head>
+<body>
+
+  <test-fixture id='basic'>
+    <template>
+      <hunk-sorter></hunk-sorter>
+    </template>
+  </test-fixture>
+
+  <script>
+  /*global testDiffs*/
+  suite('<pull-request-group> unit', function() {
+    var sorter;
+
+    setup(function() {
+      sorter = fixture('basic');
+    });
+
+    test('has default empty group', function() {
+      assert.equal(0, sorter.groups[0].diff.length);
+    });
+
+    test('orders new hunks', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      assert.deepEqual(testDiffs[0], sorter.groups[0].diff[0]);
+    });
+
+    test('adds group to the front', function() {
+      sorter.addGroup('01');
+      sorter.addGroup('02');
+      assert.equal('02', sorter.groups[0].title);
+      assert.equal('01', sorter.groups[1].title);
+    });
+
+    test('adds new empty group', function() {
+      sorter.addGroup('01');
+      assert.equal(0, sorter.groups[0].diff.length);
+    });
+
+    test('does not add duplicate groups', function() {
+      sorter.addGroup('01');
+      sorter.addGroup('01');
+      // There should be two groups because 'Unsorted changes' is the default group.
+      assert.equal(2, sorter.groups.length);
+    });
+
+    test('removes group by title', function() {
+      sorter.addGroup('01');
+      sorter.removeGroup('01');
+      assert.equal(1, sorter.groups.length);
+    });
+
+    test('does not remove too much', function() {
+      sorter.addGroup('01');
+      sorter.addGroup('02');
+      sorter.addGroup('03');
+      sorter.removeGroup('01');
+      assert.equal(3, sorter.groups.length);
+    });
+
+    test('adds hunk to correct group', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.addGroup('group');
+      assert.equal(0, sorter.groups[0].diff.length);
+      sorter.addHunkToGroup(testDiffs[0], 'group');
+      assert.equal(1, sorter.groups[0].diff.length);
+    })
+  });
+
+  </script>
+
+</body>
+</html>

--- a/test/projects/diff/hunk-sorter.html
+++ b/test/projects/diff/hunk-sorter.html
@@ -50,49 +50,73 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <script>
   /*global testDiffs*/
-  suite('<pull-request-group> unit', function() {
+  suite('<hunk-sorter> group unit', function() {
     var sorter;
 
     setup(function() {
       sorter = fixture('basic');
+      sorter._remoteOrdering = {};
     });
 
-    test('has default empty group', function() {
-      assert.equal(0, sorter.groups[0].diff.length);
+    test('has default group when there is no ordering on firebase', function() {
+      sorter.rawHunks = testDiffs;
+      assert.equal(testDiffs.length, sorter.groups[0].diff.length);
     });
 
-    test('orders new hunks', function() {
+    test('has default ordering when there is no ordering on firebase', function() {
+      sorter.rawHunks = testDiffs;
+      assert.equal(testDiffs.length, sorter._ordering[0].hunks.length);
+    });
+
+    test('orders new hunks into groups', function() {
       sorter.rawHunks = [testDiffs[0]];
       assert.deepEqual(testDiffs[0], sorter.groups[0].diff[0]);
     });
 
     test('adds group to the front', function() {
+      sorter.rawHunks = [testDiffs[0]];
       sorter.addGroup('01');
       sorter.addGroup('02');
       assert.equal('02', sorter.groups[0].title);
       assert.equal('01', sorter.groups[1].title);
     });
 
+    test('adds group to the front of _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      var id1 = sorter.addGroup('01');
+      var id2 = sorter.addGroup('02');
+      assert.equal(id2, sorter._ordering[0].id);
+      assert.equal(id1, sorter._ordering[1].id);
+    });
+
     test('adds new empty group', function() {
+      sorter.rawHunks = [testDiffs[0]];
       sorter.addGroup('01');
       assert.equal(0, sorter.groups[0].diff.length);
     });
 
-    test('does not add duplicate groups', function() {
+    test('adds new empty group to _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
       sorter.addGroup('01');
-      sorter.addGroup('01');
-      // There should be two groups because 'Unsorted changes' is the default group.
-      assert.equal(2, sorter.groups.length);
+      assert.equal(0, sorter._ordering[0].hunks.length);
     });
 
     test('removes group by id', function() {
-      sorter.addGroup('group');
-      var id = sorter.groups[0].id;
+      sorter.rawHunks = [testDiffs[0]];
+      var id = sorter.addGroup('group');
       sorter.removeGroup(id);
       assert.equal(1, sorter.groups.length);
     });
 
+    test('removes group by id from _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      var id = sorter.addGroup('group');
+      sorter.removeGroup(id);
+      assert.equal(1, sorter._ordering.length);
+    });
+
     test('does not remove too much', function() {
+      sorter.rawHunks = [testDiffs[0]];
       sorter.addGroup('01');
       sorter.addGroup('02');
       sorter.addGroup('03');
@@ -100,7 +124,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       assert.equal(3, sorter.groups.length);
     });
 
+    test('does not remove too much from _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      sorter.addGroup('01');
+      sorter.addGroup('02');
+      sorter.addGroup('03');
+      sorter.removeGroup(sorter.groups[0].id);
+      assert.equal(3, sorter._ordering.length);
+    });
+
     test('can remove middle group', function() {
+      sorter.rawHunks = [testDiffs[0]];
       sorter.addGroup('01');
       sorter.addGroup('02');
       sorter.addGroup('03');
@@ -108,13 +142,252 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       assert.equal('01', sorter.groups[1].title);
     });
 
+    test('can remove middle group from _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      var id = sorter.addGroup('01');
+      sorter.addGroup('02');
+      sorter.addGroup('03');
+      sorter.removeGroup(sorter.groups[1].id);
+      assert.equal(id, sorter._ordering[1].id);
+    });
+
+    test('can remove default group', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      sorter.addGroup('bla');
+      sorter.removeGroup(sorter.groups[1].id);
+      assert.equal(1, sorter.groups.length);
+    });
+
+    test('can remove default group from _ordering', function() {
+      sorter.rawHunks = [testDiffs[0]];
+      sorter.addGroup('bla');
+      sorter.removeGroup(sorter.groups[1].id);
+      assert.equal(1, sorter._ordering.length);
+    });
+
+    test('fills the default group when assigning unsorted hunks', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.addGroup('bla');
+      assert.equal(testDiffs.length, sorter.groups[1].diff.length);
+    });
+
+    test('fills the default group in _ordering when assigning unsorted hunks', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.addGroup('bla');
+      assert.equal(testDiffs.length, sorter._ordering[1].hunks.length);
+    });
+
     test('adds hunk to correct group', function() {
       sorter.rawHunks = testDiffs;
-      sorter.addGroup('group');
-      assert.equal(0, sorter.groups[0].diff.length);
-      sorter.addHunkToGroup(testDiffs[0], 'group');
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
       assert.equal(1, sorter.groups[0].diff.length);
-    })
+    });
+
+    test('adds hunk to correct group in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      assert.equal(1, sorter._ordering[0].hunks.length);
+    });
+
+    test('cannot add hunk to non-existing group', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], 'illegal-group-id', 0);
+      assert.equal(0, sorter.groups[0].diff.length);
+    });
+
+    test('does add hunk to non-existing group in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], 'illegal-group-id', 0);
+      assert.equal(0, sorter._ordering[0].hunks.length);
+    });
+
+    test('can add hunk to default group', function() {
+      sorter.rawHunks = [];
+      var id = sorter.groups[0].id;
+      sorter.addHunkToGroup(testDiffs[1], id, 0);
+      assert.equal(1, sorter.groups[0].diff.length);
+    });
+
+    test('adds hunk to default group in _ordering', function() {
+      sorter.rawHunks = [];
+      var id = sorter.groups[0].id;
+      sorter.addHunkToGroup(testDiffs[1], id, 0);
+      assert.equal(1, sorter._ordering[0].hunks.length);
+    });
+
+    test('adds hunk to correct location in group', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      var expectedIndex = 1, expectedHunk = testDiffs[2];
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.addHunkToGroup(testDiffs[1], id, 1);
+      sorter.addHunkToGroup(expectedHunk, id, expectedIndex);
+      assert.deepEqual(expectedHunk, sorter.groups[0].diff[expectedIndex]);
+    });
+
+    test('adds hunk to correct location in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      var expectedIndex = 1;
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.addHunkToGroup(testDiffs[1], id, 1);
+      sorter.addHunkToGroup(testDiffs[2], id, expectedIndex);
+      assert.deepEqual(getHunkId(testDiffs[2]), sorter._ordering[0].hunks[expectedIndex]);
+    });
+
+    test('removes hunk from correct group', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.addHunkToGroup(testDiffs[1], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[0]);
+      assert.equal(1, sorter.groups[0].diff.length);
+    });
+
+    test('does not remove hunk from other groups', function() {
+      sorter.rawHunks = testDiffs;
+      var id1 = sorter.addGroup('group-1');
+      var id2 = sorter.addGroup('group-2');
+      sorter.addHunkToGroup(testDiffs[0], id1, 0);
+      sorter.addHunkToGroup(testDiffs[0], id2, 0);
+      sorter.removeHunkFromGroup(id1, testDiffs[0]);
+      assert.equal(1, sorter.groups[0].diff.length);
+    });
+
+
+    test('removes hunk from correct group in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.addHunkToGroup(testDiffs[1], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[0]);
+      assert.equal(1, sorter._ordering[0].hunks.length);
+    });
+
+    test('cannot remove non-existing hunk from group', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[1]);
+      assert.equal(1, sorter.groups[0].diff.length);
+    });
+
+    test('does not remove non-existing hunk from _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[1]);
+      assert.equal(1, sorter._ordering[0].hunks.length);
+    });
+
+    test('can remove hunk from default group', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.removeHunkFromGroup(sorter.groups[0].id, testDiffs[0]);
+      assert.equal(testDiffs.length-1, sorter.groups[0].diff.length);
+    });
+
+    test('removes hunk from default group in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      sorter.removeHunkFromGroup(sorter.groups[0].id, testDiffs[0]);
+      assert.equal(testDiffs.length-1, sorter._ordering[0].hunks.length);
+    });
+
+    test('removes group when it becomes empty', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[0]);
+      assert.equal(1, sorter.groups.length);
+    });
+
+    test('removes group from _ordering when it becomes empty', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('group');
+      sorter.addHunkToGroup(testDiffs[0], id, 0);
+      sorter.removeHunkFromGroup(id, testDiffs[0]);
+      assert.equal(1, sorter._ordering.length);
+    });
+
+    test('moves correct hunk inside groups', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.groups[0].id;
+      sorter.moveHunk(id, 0, 1);
+      assert.deepEqual(testDiffs[0], sorter.groups[0].diff[1]);
+      assert.deepEqual(testDiffs[1], sorter.groups[0].diff[0]);
+    });
+
+    test('moves correct hunk inside _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.groups[0].id;
+      sorter.moveHunk(id, 0, 1);
+      assert.deepEqual(getHunkId(testDiffs[0]), sorter._ordering[0].hunks[1]);
+      assert.deepEqual(getHunkId(testDiffs[1]), sorter._ordering[0].hunks[0]);
+    });
+
+    test('does not move hunk outside bounds in groups', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.groups[0].id;
+      sorter.moveHunk(id, 0, testDiffs.length+10);
+      assert.deepEqual(testDiffs[0], sorter.groups[0].diff[testDiffs.length-1]);
+      assert.deepEqual(testDiffs[1], sorter.groups[0].diff[0]);
+    });
+
+    test('does not move hunk outside bounds in _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.groups[0].id;
+      sorter.moveHunk(id, 0, testDiffs.length+10);
+      assert.deepEqual(getHunkId(testDiffs[0]), sorter._ordering[0].hunks[testDiffs.length-1]);
+      assert.deepEqual(getHunkId(testDiffs[1]), sorter._ordering[0].hunks[0]);
+    });
+
+    test('correctly moves group', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('new-group');
+      var defaultId = sorter.groups[1].id;
+      sorter.moveGroup(0, 1);
+      assert.equal(id, sorter.groups[1].id);
+      assert.equal(defaultId, sorter.groups[0].id);
+    });
+
+    test('correctly moves group inside _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var id = sorter.addGroup('new-group');
+      var defaultId = sorter.groups[1].id;
+      sorter.moveGroup(0, 1);
+      assert.equal(id, sorter._ordering[1].id);
+      assert.equal(defaultId, sorter._ordering[0].id);
+    });
+
+    test('does not move group outside bounds', function() {
+      sorter.rawHunks = testDiffs;
+      var idFirst = sorter.addGroup('new-group');
+      var idLast = sorter.addGroup('new-group2');
+      sorter.moveGroup(0, 10);
+      assert.deepEqual(idFirst, sorter.groups[0].id);
+      assert.deepEqual(idLast, sorter.groups[2].id);
+    });
+
+    test('does not move group outside bounds inside _ordering', function() {
+      sorter.rawHunks = testDiffs;
+      var idFirst = sorter.addGroup('new-group');
+      var idLast = sorter.addGroup('new-group2');
+      sorter.moveGroup(0, 10);
+      assert.deepEqual(idFirst, sorter._ordering[0].id);
+      assert.deepEqual(idLast, sorter._ordering[2].id);
+    });
+
+
+    var getHunkId = function(hunk) {
+      return hunk.file + ',' +
+        hunk.linesChanged.startLineBefore + ',' +
+        hunk.linesChanged.rangeBefore + ',' +
+        hunk.linesChanged.startLineAfter + ',' +
+        hunk.linesChanged.rangeAfter;
+    }
   });
 
   </script>

--- a/test/projects/diff/test-diffs.js
+++ b/test/projects/diff/test-diffs.js
@@ -64,10 +64,10 @@ var actualDiffs = [
 
   {
     file: 6,
-    diff: 'diff --git a/a b/a\n' +
+    diff: 'diff --git a/b b/b\n' +
           'index 0a96631..c8f047a 100644\n' +
-          '--- a/a\n' +
-          '+++ b/a\n' +
+          '--- a/b\n' +
+          '+++ b/b\n' +
           '@@ -1,5 +1,5 @@\n' +
           ' one line\n' +
           ' line inbetween\n' +

--- a/test/projects/diff/test-diffs.js
+++ b/test/projects/diff/test-diffs.js
@@ -258,9 +258,9 @@ var testDiffs = [
   },
   {
     index: '6',
-    file: 'a',
+    file: 'b',
     diffId: '@@ -1,5 +1,5 @@',
-    fileUrl: 'base/blob/sha/a',
+    fileUrl: 'base/blob/sha/b',
     changes: "\n one line\n" +
     " line inbetween\n" +
     "-another line\n" +


### PR DESCRIPTION
The `hunk-sorter` now **fully** maintains changes in the ordering passed from the UI and reflects them back to its `groups` property. It also comes with _42_ tests (no this is not intentional).
