### PR TITLE
Refactor generaterequest to not throw undefined errors

### DIFF
--- a/src/ajax/backend-ajax.html
+++ b/src/ajax/backend-ajax.html
@@ -92,18 +92,6 @@ of params with oAuth tokens.
           access_token: accessToken
         };
       },
-      /**
-       * Performs an AJAX request to the specified URL.
-       *
-       * @return {!IronRequestElement}
-       */
-      generateRequest: function() {
-        if (!this.shared.accessToken) {
-          this._fireLater = true;
-          return;
-        }
-        return this.$.ajax.generateRequest();
-      },
       _onResponse: function(e) {
         this._setLastResponse(e.detail.response);
         this.fire('response', e.detail, {

--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -73,9 +73,6 @@ of the GitHub oAuth token.
       },
       attached: function() {
         this._parseSuccesfulResult = this._parseSuccesfulResult.bind(this);
-        if (this.$.auth.auth) {
-          this.signIn();
-        }
       },
       /**
        * Sign in the user with Firebase. It checks if the redirect was succesful.

--- a/src/ajax/github-authenticated-ajax.html
+++ b/src/ajax/github-authenticated-ajax.html
@@ -116,19 +116,6 @@ of params with oAuth tokens.
           this._setHeader('If-None-Match', etag);
         }
       },
-      /**
-       * Performs an AJAX request to the specified URL.
-       *
-       * @return {!IronRequestElement}
-       */
-      generateRequest: function() {
-        this._updateIfNoneMatch(this.refurl);
-        if (!this.shared.accessToken) {
-          this._fireLater = true;
-          return;
-        }
-        return this.$.ajax.generateRequest();
-      },
       _onResponse: function(e) {
         shared.headerCache[this.refurl] = e.detail.xhr.getResponseHeader('ETag');
         shared.responseCache[this.refurl] = e.detail.response;

--- a/src/ajax/iron-ajax-properties.html
+++ b/src/ajax/iron-ajax-properties.html
@@ -288,7 +288,7 @@ var IronAjaxProperties = (function() {
         this.shared = shared;
         if (this._fireLater) {
           this._fireLater = false;
-          this.$.ajax.generateRequest();
+          this.generateRequest();
         }
       }.bind(this));
     },
@@ -299,6 +299,18 @@ var IronAjaxProperties = (function() {
       if (this.auto && !this.loading) {
         this.generateRequest();
       }
+    },
+    /**
+     * Performs an AJAX request to the specified URL.
+     *
+     * @return {!IronRequestElement}
+     */
+    generateRequest: function() {
+      if (!this.params) {
+        this._fireLater = true;
+        return;
+      }
+      return this.$.ajax.generateRequest();
     },
     /**
      * Static function to insert the oAuth token and make sure all

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -175,6 +175,11 @@ Prism.languages.diff.other = /.+/m;
       'github-token': '_setToken',
       'go-login-github': '_signInWithGitHub'
     },
+    attached: function() {
+      if (this.page.page !== '') {
+        this._signInWithGitHub();
+      }
+    },
     _equals: function(one, other) {
       return one === other;
     },


### PR DESCRIPTION
Requests are now waiting for `this.params` instead, to make sure the observer triggered first.
Also moved the Firebase request to `rite-app` to make sure you do not log in when browsing the home-page.

Fixes #183 
