### PR TITLE
Improve group style to take less vertical space

### DIFF
--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -60,10 +60,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
       header {
         min-height: 2em;
-        margin-bottom: 3em;
       }
       h2.title {
         height: 25px;
+      }
+      markdown-input {
+        margin-bottom: 1em;
+      }
+      markdown-input[disabled] {
+        margin-bottom: 0;
       }
       #hunks {
         width: 100%;
@@ -145,14 +150,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <div class="content" hidden$="[[collapsed]]">
       <header>
         <editable-title id="editTitleDialog" editable="[[editable]]" value="{{group.info.title}}"></editable-title>
-        <markdown-input
-          hidden$="[[hideDescription]]"
-          disabled="[[!editable]]"
-          label="Enter a description for these changes. Markdown is supported."
-          markdown="{{group.info.description}}"
-          project="[[project]]"
-        ></markdown-input>
       </header>
+
+      <markdown-input
+        hidden$="[[hideDescription]]"
+        disabled="[[!editable]]"
+        label="Enter a description for these changes. Markdown is supported."
+        markdown="{{group.info.description}}"
+        project="[[project]]"
+      ></markdown-input>
+
       <dom-repeat-once id="hunks" items="[[group.diff]]" disabled="[[!editable]]"></dom-repeat-once>
       <p class="toggle-comments" hidden$="[[editable]]">
         <span>comments</span>

--- a/src/util/markdown-input.html
+++ b/src/util/markdown-input.html
@@ -26,7 +26,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<link rel="import" href="../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-input/paper-textarea.html">
 <link rel="import" href="../util/marked-github-element.html">
 
@@ -38,13 +38,13 @@ after toggling the preview showing the rendered markdown in real-time.
   <template>
     <style>
       :host {
-        display: block;
+        display: flex;
         padding: 1em;
+        padding-left: 0.5em;
         border: solid 1px transparent;
       }
       :host([disabled]) {
-        border: 0;
-        background-color: transparent;
+        padding: 0;
       }
       :host(.noPreview) {
         border: solid 1px var(--secondary-background-color);
@@ -53,9 +53,10 @@ after toggling the preview showing the rendered markdown in real-time.
       [hidden] {
         display: none !important;
       }
-      paper-textarea,
-      marked-github-element {
+      .edit-area {
+        flex: 1;
         line-height: 1.4em;
+        padding-left: 0.5em;
       }
       paper-textarea {
         --paper-input-container: {
@@ -68,27 +69,23 @@ after toggling the preview showing the rendered markdown in real-time.
         --paper-input-container-focus-color: var(--anchor-color);
       }
 
-      paper-button {
-        transition:
-        font-size: 14px;
+      paper-icon-button {
         margin-top: 1em;
-        background-color: var(--secondary-background-color);
-        color: var(--primary-text-color);
-        --paper-button-ink-color: var(--anchor-hover-color);
       }
-      paper-button:hover,
-      paper-button[active] {
-        color: var(--primary-background-color);
-        background-color: var(--anchor-color);
+      paper-icon-button:hover,
+      paper-icon-button[active] {
+        color: var(--anchor-color);
       }
       marked-github-element {
         margin-top: 16px;
         min-height: 50px;
       }
     </style>
-    <paper-textarea hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
-    <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]" project="[[project]]"></marked-github-element>
-    <paper-button toggles raised hidden$="[[disabled]]" active="{{_previewToggle}}">[[_toggleText]]</paper-button>
+    <div class="edit-area">
+      <paper-textarea hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
+      <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]" project="[[project]]"></marked-github-element>
+    </div>
+    <paper-icon-button toggles icon="icons:visibility" hidden$="[[disabled]]" active="{{_previewToggle}}" title="Toggle Markdown preview">[[_toggleText]]</paper-icon-button>
   </template>
   <script>
     Polymer({
@@ -105,7 +102,8 @@ after toggling the preview showing the rendered markdown in real-time.
          */
         disabled: {
           type: Boolean,
-          value: false
+          value: false,
+          reflectToAttribute: true
         },
         /**
          * The markdown from the input field to be rendered to markdown HTML.


### PR DESCRIPTION
Before:
![screenshot from 2016-06-12 15 28 03](https://cloud.githubusercontent.com/assets/5946422/15991409/48e5b664-30b2-11e6-8d0c-4325d4a2a8b0.png)

![screenshot from 2016-06-12 15 27 23](https://cloud.githubusercontent.com/assets/5946422/15991404/349f4242-30b2-11e6-92fc-285982b6fd48.png)

After:
![screenshot from 2016-06-12 15 25 51](https://cloud.githubusercontent.com/assets/5946422/15991391/f9895e7c-30b1-11e6-9926-e917e40f3487.png)

![screenshot from 2016-06-12 15 26 26](https://cloud.githubusercontent.com/assets/5946422/15991395/0bf22ee0-30b2-11e6-91ae-08a5ce6484ff.png)
