### PR TITLE
Extract ProjectBehavior for project object delegation

### DIFF
--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -82,7 +82,7 @@ of the GitHub oAuth token.
        * Else it checks for local storage if the token existed and signed in
        * with the Firebase session and fires `github-token` again.
        */
-      signIn: function() {
+      signIn: function(shouldRedirect) {
         this.$.auth.auth.getRedirectResult().then(function(result) {
           this.loading = false;
           if (!result.credential) {
@@ -90,7 +90,9 @@ of the GitHub oAuth token.
               this.fire('github-token', this._tokens.GitHub);
               return;
             }
-            this._redirectToGitHub();
+            if (shouldRedirect) {
+              this._redirectToGitHub();
+            }
           } else {
             this._parseSuccesfulResult(result);
           }

--- a/src/list-items/column-list-item.html
+++ b/src/list-items/column-list-item.html
@@ -79,7 +79,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'column-list-item',
       properties: {
-        project: Object,
         focused: {
           type: Boolean,
           reflectToAttribute: true

--- a/src/projects/create-pull-request/create-pull-request-description.html
+++ b/src/projects/create-pull-request/create-pull-request-description.html
@@ -63,7 +63,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <paper-input class="title" label="Enter a pull request title" value="{{title}}"></paper-input>
     <markdown-input
       label="Enter a description for your pull request. Markdown is supported."
-      project="[[project]]"
       markdown="{{description}}"></markdown-input>
   </template>
   <script>
@@ -71,7 +70,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'project-create-pull-request-description',
       properties: {
-        project: Object,
         title: {
           type: String,
           notify: true

--- a/src/projects/create-pull-request/create-pull-request.html
+++ b/src/projects/create-pull-request/create-pull-request.html
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../../ajax/github-authenticated-ajax.html">
 <link rel="import" href="../../ajax/backend-ajax.html">
 <link rel="import" href="../diff/diff.html">
+<link rel="import" href="../project-behavior.html">
 <link rel="import" href="create-pull-request-description.html">
 <link rel="import" href="create-pull-diff.html">
 
@@ -129,10 +130,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ></project-create-pull-diff>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'project-create-pull-request',
+      behaviors: [ProjectBehavior],
       properties: {
-        project: Object,
         title: String,
         description: String,
         contributors: Array,

--- a/src/projects/diff/diff.html
+++ b/src/projects/diff/diff.html
@@ -91,11 +91,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
     </style>
     <diff-parser diff="[[diff]]" base-url="[[baseUrl]]" sha="[[sha]]" additions="{{additions}}" deletions="{{deletions}}" hunks="{{hunks}}"></diff-parser>
-    <hunk-sorter id="sorter" raw-hunks="[[hunks]]" groups="{{orderedGroups}}" project="[[project]]"></hunk-sorter>
+    <hunk-sorter id="sorter" raw-hunks="[[hunks]]" groups="{{orderedGroups}}"></hunk-sorter>
 
     <div id="hunkGroups">
       <template is="dom-repeat" items="[[orderedGroups]]">
-        <pull-request-group group="[[item]]" editable="[[editable]]" project="[[project]]"></pull-request-group>
+        <pull-request-group group="[[item]]" editable="[[editable]]"></pull-request-group>
       </template>
     </div>
 
@@ -121,7 +121,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'pull-request-diff',
       properties: {
-        project: Object,
         editable: {
           type: Boolean,
           value: false

--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -153,7 +153,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           disabled="[[!editable]]"
           label="Enter a description for these changes. Markdown is supported."
           markdown="{{group.info.description}}"
-          project="[[project]]"
         ></markdown-input>
 
         <dom-repeat-once id="hunks" items="[[group.diff]]" disabled="[[!editable]]"></dom-repeat-once>
@@ -163,7 +162,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <template is="dom-repeat" items="[[group.comments]]" as="comment">
               <pull-request-comment
               text="[[comment.body]]" author="[[comment.user]]"
-              date="[[comment.timeopened]]" project="[[project]]"></pull-request-comment>
+              date="[[comment.timeopened]]"></pull-request-comment>
             </template>
             <pull-request-add-comments comments="{{group.comments}}"></pull-request-add-comments>
           </div>
@@ -195,7 +194,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           value: false,
           reflectToAttribute: true
         },
-        project: Object,
         _isAlreadyInitialized: Boolean
       },
       observers: [

--- a/src/projects/navigation/list-navigation.html
+++ b/src/projects/navigation/list-navigation.html
@@ -135,7 +135,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
       <project-pull-requests
           class$="pull-list [[showPullList]]" route="{{nameTail}}" tabindex="0"
-          project="[[project]]" pullrequests="[[pullrequests]]"
+          pullrequests="[[pullrequests]]"
           selected-pull="[[selectedPull]]"></project-pull-requests>
     </div>
   </template>
@@ -146,7 +146,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       behaviors: [SearchBehavior],
       properties: {
         route: Object,
-        project: Object,
         nameTail: Object,
         showProjectsList: {
           type: Boolean,

--- a/src/projects/navigation/project-pull-requests.html
+++ b/src/projects/navigation/project-pull-requests.html
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 <link rel="import" href="../../list-items/preview-list.html">
 <link rel="import" href="../pull-request/pull-request-page.html">
+<link rel="import" href="../project-behavior.html">
 <link rel="import" href="project-pull-request-list-item.html">
 <link rel="import" href="search-box.html">
 <link rel="import" href="search-behavior.html">
@@ -124,12 +125,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </preview-list>
   </template>
   <script>
-  /*global SearchBehavior*/
+  /*global SearchBehavior,ProjectBehavior*/
     Polymer({
       is: 'project-pull-requests',
-      behaviors: [SearchBehavior],
+      behaviors: [SearchBehavior, ProjectBehavior],
       properties: {
-        project: Object,
         route: Object,
         selectedPull: Object,
         pullrequests: {

--- a/src/projects/no-project-selected.html
+++ b/src/projects/no-project-selected.html
@@ -53,10 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <script>
     Polymer({
-      is: 'no-project-selected',
-      properties: {
-        project: Object
-      }
+      is: 'no-project-selected'
     });
   </script>
 </dom-module>

--- a/src/projects/project-activity.html
+++ b/src/projects/project-activity.html
@@ -93,7 +93,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     Polymer({
       is: 'project-activity',
         properties: {
-          project: Object,
           selected: {
             type: String
           },

--- a/src/projects/project-behavior.html
+++ b/src/projects/project-behavior.html
@@ -1,0 +1,27 @@
+<script>
+/*exported ProjectBehavior*/
+var ProjectBehavior = (function() {
+  var instances = [];
+
+  return {
+    properties: {
+      project: Object
+    },
+    attached: function() {
+      instances.push(this);
+    },
+    detached: function() {
+      var index = instances.indexOf(this);
+      if (!index) {
+        return;
+      }
+      instances.splice(index, 1);
+    },
+    setProject: function(project) {
+      for (var i=0, l=instances.length;i<l;i++) {
+        instances[i].project = project;
+      }
+    }
+  };
+})();
+</script>

--- a/src/projects/project-overview-page.html
+++ b/src/projects/project-overview-page.html
@@ -113,6 +113,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'project-overview-page',
       behaviors: [ProjectBehavior],

--- a/src/projects/project-overview-page.html
+++ b/src/projects/project-overview-page.html
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../bower_components/paper-toolbar/paper-toolbar.html">
 <link rel="import" href="../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="create-pull-request/create-pull-request.html">
+<link rel="import" href="project-behavior.html">
 <link rel="import" href="project-activity.html">
 <link rel="import" href="info-header.html">
 
@@ -102,8 +103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 attr-for-selected="data-route"
                 fallback-selection="404">
       <project-activity data-route="activity"></project-activity>
-      <project-create-pull-request data-route="createpull"
-          project="[[project]]"></project-create-pull-request>
+      <project-create-pull-request data-route="createpull"></project-create-pull-request>
       <span data-route="404">
         Oops you hit a 404!
         <a href="/">Head back home</a>
@@ -115,8 +115,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script>
     Polymer({
       is: 'project-overview-page',
+      behaviors: [ProjectBehavior],
       properties: {
-        project: Object,
         route: Object,
         page: Object
       }

--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -106,6 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </iron-pages>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'projects-page',
       properties: {

--- a/src/projects/projects-page.html
+++ b/src/projects/projects-page.html
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../ajax/github-authenticated-ajax.html">
 <link rel="import" href="../list-items/list-tab.html">
 <link rel="import" href="../list-items/preview-list.html">
+<link rel="import" href="project-behavior.html">
 <link rel="import" href="navigation/list-navigation.html">
 <link rel="import" href="pull-request/pull-request-page.html">
 <link rel="import" href="no-project-selected.html">
@@ -100,8 +101,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         on-tap="_tapHideProjectList">
       <no-project-selected data-route="no-selected"></no-project-selected>
       <project-overview-page data-route="overview" tabindex="0"
-          project="[[activeProject]]" route="{{nameTail}}" pullrequests="[[pullrequests]]"></project-overview-page>
-      <pull-request-page data-route="pr" selected-pull="{{selectedPull}}" route="{{prTail}}" project="[[projectTitle]]"></pull-request-page>
+          route="{{nameTail}}" pullrequests="[[pullrequests]]"></project-overview-page>
+      <pull-request-page data-route="pr" selected-pull="{{selectedPull}}" route="{{prTail}}"></pull-request-page>
     </iron-pages>
   </template>
   <script>
@@ -179,6 +180,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           name: project.name,
           _actual: project
         };
+        ProjectBehavior.setProject(this.activeProject);
+
         if (this.githubPath) {
           this.pullRequestPagination = 1;
           this._lastPage = undefined;

--- a/src/projects/pull-request/pr-status.html
+++ b/src/projects/pull-request/pr-status.html
@@ -31,8 +31,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../../bower_components/polymerfire/firebase-document.html">
 <link rel="import" href="../../ajax/backend-ajax.html">
-
 <link rel="import" href="../../list-items/list-item-label.html">
+<link rel="import" href="../project-behavior.html">
+
 <dom-module id="pr-status">
   <template>
     <style>
@@ -65,6 +66,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script>
     Polymer({
       is: 'pr-status',
+      behaviors: [ProjectBehavior],
       properties: {
         statuses: {
           type: Array,
@@ -77,7 +79,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         },
         sendStatus: String,
         pullRequest: Object,
-        project: Object,
         statusPath: {
           type: String,
           computed: '_updateStatusPath(project, pullRequest)'

--- a/src/projects/pull-request/pr-status.html
+++ b/src/projects/pull-request/pr-status.html
@@ -64,6 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </paper-dropdown-menu>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'pr-status',
       behaviors: [ProjectBehavior],

--- a/src/projects/pull-request/pull-request-add-comments.html
+++ b/src/projects/pull-request/pull-request-add-comments.html
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         width: 150px;
       }
     </style>
-    <markdown-input markdown="{{newtext}}" project="[[project]]" label="Leave a comment."></markdown-input>
+    <markdown-input markdown="{{newtext}}" label="Leave a comment."></markdown-input>
     <paper-button raised class="button" on-tap="_addComment">New comment</paper-button>
   </template>
   <script>

--- a/src/projects/pull-request/pull-request-changes.html
+++ b/src/projects/pull-request/pull-request-changes.html
@@ -67,14 +67,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         groups="[[orderedGroups]]" hidden$="[[!showSpace]]"></pull-request-space>
     <pull-request-diff id="diff" data-route="diff" diff="[[diff]]"
         ordered-groups="{{orderedGroups}}" base-url="[[baseUrl]]"
-        sha="[[sha]]" project="[[project]]"></pull-request-diff>
+        sha="[[sha]]"></pull-request-diff>
 
   </template>
   <script>
     Polymer({
       is: 'pull-request-changes',
       properties: {
-        project: Object,
         diff: String,
         baseUrl: String,
         sha: String,

--- a/src/projects/pull-request/pull-request-comment.html
+++ b/src/projects/pull-request/pull-request-comment.html
@@ -75,7 +75,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <a-user user="[[author]]"></a-user>
         <list-item-label class="time" type="info" icon="device:access-time" title$="Posted [[_timeString]] ago">[[_timeString]] ago</list-item-label>
       </div>
-      <marked-github-element markdown="[[text]]" project="[[project]]"></marked-github-element>
+      <marked-github-element markdown="[[text]]"></marked-github-element>
     </div>
 
   </template>
@@ -88,7 +88,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         text: String,
         author: Object,
         date: String,
-        project: Object,
         _timeString: {
           type: String,
           computed: 'toDateString(date)'

--- a/src/projects/pull-request/pull-request-comments.html
+++ b/src/projects/pull-request/pull-request-comments.html
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <preview-list hide-end-indicator>
       <template is="dom-repeat" items="[[orderedComments]]">
         <pull-request-comment text="[[item.body]]" author="[[item.user]]"
-          date="[[item.created_at]]" project="[[project]]"></pull-request-comment>
+          date="[[item.created_at]]"></pull-request-comment>
       </template>
     </preview-list>
   </template>
@@ -53,8 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         orderedComments: {
           type: Array,
           computed: '_reverse(comments)'
-        },
-        project: Object
+        }
       },
       _reverse: function(array) {
         if (array) {

--- a/src/projects/pull-request/pull-request-commit.html
+++ b/src/projects/pull-request/pull-request-commit.html
@@ -101,7 +101,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           <img class="icon" src="[[item.author.avatar_url]]" alt="[[item.author.login]] avatar"/>
         </div>
         <div class$="container [[showWholeMessage]]" on-tap="_showWholeCommit">
-          <marked-github-element class="message" markdown="[[item.commit.message]]" project="[[project]]"></marked-github-element>
+          <marked-github-element class="message" markdown="[[item.commit.message]]"></marked-github-element>
         </div>
       </div>
     </div>
@@ -112,7 +112,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       is: 'pull-request-commit',
       behaviors: [ToDateStringBehavior, SubstituteRenderedGitHubMarkdownBehavior],
       properties: {
-        project: Object,
         item: Object,
         showWholeMessage: {
           type: Boolean,

--- a/src/projects/pull-request/pull-request-commits.html
+++ b/src/projects/pull-request/pull-request-commits.html
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       last-response="{{commits}}"></github-authenticated-ajax>
 
     <template is="dom-repeat" items="{{commits}}" index-as="index">
-      <pull-request-commit item="[[item]]" project="[[project]]"></pull-request-commit>
+      <pull-request-commit item="[[item]]"></pull-request-commit>
     </template>
   </template>
   <script>
@@ -54,8 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       is: 'pull-request-commits',
       properties: {
         pullRequest: Object,
-        commits: Array,
-        project: Object
+        commits: Array
       },
       observers: [
         '_fireAjax(pullRequest)'

--- a/src/projects/pull-request/pull-request-general-information.html
+++ b/src/projects/pull-request/pull-request-general-information.html
@@ -137,12 +137,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </header>
       <section>
         <div>
-          <marked-github-element markdown="[[pullRequest.body]]" project="[[project]]"></marked-github-element>
+          <marked-github-element markdown="[[pullRequest.body]]"></marked-github-element>
           <pull-request-add-comments comments="{{comments}}"></pull-request-add-comments>
         </div>
         <div class="sidebar">
-          <pr-status pull-request="[[pullRequest]]" project="[[project]]"></pr-status>
-          <reviewers-list pullrequest="{{pullRequest}}" project="[[project]]"></reviewers-list>
+          <pr-status pull-request="[[pullRequest]]"></pr-status>
+          <reviewers-list pullrequest="{{pullRequest}}"></reviewers-list>
           <tags-list>
             <template is="dom-repeat" items="[[issue.labels]]">
               <tag-list-item backgroundcolor="[[item.color]]">[[item.name]]</tag-list-item>
@@ -160,7 +160,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </paper-button>
     </div>
 
-    <pull-request-comments comments="{{comments}}" project="[[project]]"></pull-request-comments>
+    <pull-request-comments comments="{{comments}}"></pull-request-comments>
   </template>
   <script>
   /*global ToDateStringBehavior*/
@@ -170,7 +170,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       properties: {
         comments: Array,
         issue: Object,
-        project: Object,
         pullRequest: {
           type: Object,
           notify: true

--- a/src/projects/pull-request/pull-request-page.html
+++ b/src/projects/pull-request/pull-request-page.html
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../../bower_components/iron-ajax/iron-ajax.html">
 <link rel="import" href="../info-header.html">
+<link rel="import" href="../project-behavior.html">
 <link rel="import" href="pull-request-general-information.html">
 <link rel="import" href="pull-request-changes.html">
 <link rel="import" href="pull-request-commits.html">
@@ -151,8 +152,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         pull-request="{{selectedPull}}" project="[[project]]"></pull-request-general-information>
       <pull-request-commits data-route="commits" pull-request="[[selectedPull]]" project="[[project]]"></pull-request-commits>
       <pull-request-changes data-route="diff" diff="[[diff]]" base-url="[[selectedPull.head.repo.html_url]]"
-          project="[[project]]" show-space="[[_showSpace]]"
-          sha="[[selectedPull.head.sha]]"></pull-request-changes>
+          show-space="[[_showSpace]]" sha="[[selectedPull.head.sha]]"></pull-request-changes>
 
       <span data-route="404">
         Oops you hit a 404!
@@ -163,9 +163,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script>
     Polymer({
       is: 'pull-request-page',
+      behaviors: [ProjectBehavior],
       properties: {
         route: Object,
-        project: Object,
         diff: String,
         selectedPull: {
           type: Object,

--- a/src/projects/pull-request/pull-request-page.html
+++ b/src/projects/pull-request/pull-request-page.html
@@ -161,6 +161,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </iron-pages>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'pull-request-page',
       behaviors: [ProjectBehavior],

--- a/src/projects/pull-request/reviewers-list.html
+++ b/src/projects/pull-request/reviewers-list.html
@@ -102,6 +102,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'reviewers-list',
       behaviors: [ProjectBehavior],

--- a/src/projects/pull-request/reviewers-list.html
+++ b/src/projects/pull-request/reviewers-list.html
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <link rel="import" href="../../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../project-behavior.html">
 <link rel="import" href="set-reviewers.html">
 
 <dom-module id="reviewers-list">
@@ -97,19 +98,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </div>
       </div>
     </template>
-    <set-reviewers pullrequest="{{pullrequest}}" project="[[project]]"></set-reviewers>
+    <set-reviewers pullrequest="{{pullrequest}}"></set-reviewers>
 
   </template>
   <script>
     Polymer({
       is: 'reviewers-list',
+      behaviors: [ProjectBehavior],
       properties: {
         sortedReviewers: Array,
         pullrequest: {
           type: Object,
           notify: true
         },
-        project: Object,
         githubPathPost: {
           type: String,
           computed: '_githubPathPost(project, pullrequest)'
@@ -122,10 +123,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         'resort': '_resort'
       },
       _sortReviewers: function(pullrequest) {
-          var rs = pullrequest.assignees;
-          if (pullrequest.assignees) {
-            this.sortedReviewers = rs.sort(function(r1, r2) {
-              return r2.lgtm - r1.lgtm;
+        if (!pullrequest) {
+          return [];
+        }
+        var rs = pullrequest.assignees;
+        if (pullrequest.assignees) {
+          this.sortedReviewers = rs.sort(function(r1, r2) {
+            return r2.lgtm - r1.lgtm;
           });
         }
       },
@@ -139,7 +143,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         this._sortReviewers(this.pullrequest);
       },
       _removeAssignee: function(e) {
-        console.log(e);
         this.$.removeAssignees.body = {
           assignees: [e.path[4].getAttribute('title')]
         }

--- a/src/projects/pull-request/set-reviewers.html
+++ b/src/projects/pull-request/set-reviewers.html
@@ -27,10 +27,11 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<link rel="import" href="../../ajax/github-authenticated-ajax.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../../bower_components/paper-menu/paper-menu.html">
 <link rel="import" href="../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../../ajax/github-authenticated-ajax.html">
+<link rel="import" href="../project-behavior.html">
 
 <dom-module id="set-reviewers">
   <template>
@@ -64,12 +65,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script>
     Polymer({
       is: 'set-reviewers',
+      behaviors: [ProjectBehavior],
       properties: {
         pullrequest: {
           type: Object,
           notify: true
         },
-        project: Object,
         reviewer: String,
         githubPathPost: {
           type: String,

--- a/src/projects/pull-request/set-reviewers.html
+++ b/src/projects/pull-request/set-reviewers.html
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </paper-dropdown-menu>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'set-reviewers',
       behaviors: [ProjectBehavior],

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -176,15 +176,13 @@ Prism.languages.diff.other = /.+/m;
       'go-login-github': '_signInWithGitHub'
     },
     attached: function() {
-      if (this.page.page !== '') {
-        this._signInWithGitHub();
-      }
+      this.$.firebase.signIn(this.page.page !== '');
     },
     _equals: function(one, other) {
       return one === other;
     },
     _signInWithGitHub: function() {
-      this.$.firebase.signIn();
+      this.$.firebase.signIn(true);
     },
     _setToken: function(e) {
       this.$.authenticatedAjax.storeToken(e.detail);

--- a/src/util/markdown-input.html
+++ b/src/util/markdown-input.html
@@ -83,7 +83,7 @@ after toggling the preview showing the rendered markdown in real-time.
     </style>
     <div class="edit-area">
       <paper-textarea hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
-      <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]" project="[[project]]"></marked-github-element>
+      <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]"></marked-github-element>
     </div>
     <paper-icon-button toggles icon="icons:visibility" hidden$="[[disabled]]" active="{{_previewToggle}}" title="Toggle Markdown preview">[[_toggleText]]</paper-icon-button>
   </template>
@@ -91,11 +91,6 @@ after toggling the preview showing the rendered markdown in real-time.
     Polymer({
       is: 'markdown-input',
       properties: {
-        /**
-         * The project required to generate GitHub Markdown.
-         * @type {Object}
-         */
-        project: Object,
         /**
          * If the toggle button should be hidden.
          * @type {Boolean}

--- a/src/util/marked-github-element.html
+++ b/src/util/marked-github-element.html
@@ -126,6 +126,7 @@ Element that shows GitHub flavored markdown.
     </marked-element>
   </template>
   <script>
+  /*global ProjectBehavior*/
     Polymer({
       is: 'marked-github-element',
       behaviors: [SubstituteRenderedGitHubMarkdownBehavior, ProjectBehavior],

--- a/src/util/marked-github-element.html
+++ b/src/util/marked-github-element.html
@@ -27,6 +27,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <link rel="import" href="../bower_components/marked-element/marked-element.html">
+<link rel="import" href="../projects/project-behavior.html">
 
 <script>
 var SubstituteRenderedGitHubMarkdownBehavior = (function() {
@@ -127,13 +128,8 @@ Element that shows GitHub flavored markdown.
   <script>
     Polymer({
       is: 'marked-github-element',
-      behaviors: [SubstituteRenderedGitHubMarkdownBehavior],
+      behaviors: [SubstituteRenderedGitHubMarkdownBehavior, ProjectBehavior],
       properties: {
-        /**
-         * The project to generate GitHub flavored markdown for.
-         * @type {Object}
-         */
-        project: Object,
         /**
          * The markdown to be transformed into rendered HTML.
          * @type {String}


### PR DESCRIPTION
Whenever you require the current project, use `ProjectBehavior` now.

Fixes #250 
