### PR TITLE
Reduce FOUC in pull-requests-list

### DIFF
--- a/src/projects/navigation/list-navigation.html
+++ b/src/projects/navigation/list-navigation.html
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
       .project-list,
       .pull-list {
-        overflow: auto;
+        overflow-y: scroll;
         position: absolute;
         width: var(--project-list-width);
         left: -var(--project-list-width);

--- a/src/projects/navigation/project-pull-request-list-item.html
+++ b/src/projects/navigation/project-pull-request-list-item.html
@@ -42,6 +42,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       :host {
         outline: none;
       }
+      [hidden] {
+        display: none !important;
+      }
       .indicator.true {
         background-color: var(--primary-action-red);
       }
@@ -58,10 +61,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       .icon-passed:not(.success) {
         display: none;
       }
-      .main iron-icon {
+      .main iron-icon, .ci-placeholder {
         width: 20px;
         height: 20px;
         margin-top: -4px;
+        display: inline-block;
+      }
+      .main span {
+        line-height: 24px;
+      }
+      .main a {
+        text-decoration: none;
+      }
+      .main .labels {
+        height: 24px;
       }
     </style>
 
@@ -81,16 +94,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </div>
       <div class="main">
         <list-item-label type="title">
-        <a href$="{{_cistatus.target_url}}" target="_blank"><iron-icon title="CI passed" class$="icon-passed [[_cistatus.state]]" icon="icons:check-circle"></iron-icon></a>
-        <a href$="{{_cistatus.target_url}}" target="_blank"><iron-icon title="CI failed" class$="icon-failed [[_cistatus.state]]" icon="icons:cancel"></iron-icon></a>
+          <span class="ci-placeholder" hidden$="[[_hasCIStatus]]"></span>
+          <span hidden$="[[!_hasCIStatus]]">
+            <a href$="{{_cistatus.target_url}}" target="_blank">
+              <iron-icon title="CI passed" class$="icon-passed [[_cistatus.state]]" icon="icons:check-circle"></iron-icon>
+            </a>
+            <a href$="{{_cistatus.target_url}}" target="_blank">
+              <iron-icon title="CI failed" class$="icon-failed [[_cistatus.state]]" icon="icons:cancel"></iron-icon>
+            </a>
+          </span>
           <span title$="[[pr.title]]">[[pr.title]]</span>
         </list-item-label>
         <list-item-label type="subtitle">[[pr.user.login]]</list-item-label>
-        <list-item-label type="box" title="Status" hidden$="[[_hasLabels(showStatus, issue)]]">[[_getLabelNames(issue.labels)]]</list-item-label>
+        <span class="labels">
+          <list-item-label type="box" title="Status" hidden$="[[_shouldHideLabels]]">[[_getLabelNames(issue.labels)]]</list-item-label>
+        </span>
       </div>
       <div class="info">
         <list-item-label type="info" title$="Last updated [[_updatedAtString]] ago" icon="device:access-time">[[_updatedAtString]]</list-item-label>
-        <list-item-label type="info" title="Amount of reviewers" icon="social:people-outline">2</list-item-label>
+        <list-item-label type="info" title="Amount of reviewers" icon="social:people-outline">[[pr.assignees.length]]</list-item-label>
         <!-- <list-item-label type="info" title="Amount of reviewers" icon="social:people-outline">[[pr.assignee.login]]</list-item-label> -->
       </div>
     </column-list-item>
@@ -114,6 +136,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         showStatus: Boolean,
         selected: Boolean,
         statuses: Array,
+        _shouldHideLabels: {
+          type: Boolean,
+          value: true,
+          computed: '_hasNoLabels(showStatus, issue)'
+        },
         _cistatus: {
           type: String,
           computed: '_getCIStatus(statuses)'
@@ -121,14 +148,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         _updatedAtString: {
           type: String,
           computed: 'toDateString(pr.updated_at)'
+        },
+        _hasCIStatus: {
+          type: Boolean,
+          value: false,
+          computed: '_has(_cistatus)'
         }
       },
       observers: [
         '_fireAjax(pr)',
         '_setStatus(pr, issue)'
       ],
-      _hasLabels: function(showStatus, issue) {
+      _hasNoLabels: function(showStatus, issue) {
         return !showStatus || !issue.labels.length;
+      },
+      _has: function(value) {
+        return !!value;
       },
       _getLabelNames: function(labels) {
         return labels.map(function(label) {

--- a/src/projects/navigation/project-pull-request-list-item.html
+++ b/src/projects/navigation/project-pull-request-list-item.html
@@ -41,6 +41,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <style>
       :host {
         outline: none;
+        display: block;
+      }
+      @keyframes fadein {
+          from { opacity: 0; }
+          to   { opacity: 1; }
       }
       [hidden] {
         display: none !important;
@@ -66,6 +71,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         height: 20px;
         margin-top: -4px;
         display: inline-block;
+      }
+      .main iron-icon {
+        animation: fadein 1s;
       }
       .main span {
         line-height: 24px;


### PR DESCRIPTION
When you refresh/open the page, the elements will not jump around. The CI status now has a placeholder to make sure the text does not jump. The labels also have a height set so we do not see a tiny gray dot while the network request is still underway.
