### PR TITLE
Fixed the lgtm icon on the review hunks

### DIFF
--- a/src/projects/pull-request/reviewers-list.html
+++ b/src/projects/pull-request/reviewers-list.html
@@ -143,6 +143,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           type: Object,
           notify: true
         },
+        approvals: Object,
         githubPathPost: {
           type: String,
           computed: '_githubPathPost(project, pullRequest)'
@@ -151,10 +152,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       observers: [
         '_updateReviewers(pullRequest)',
         '_updateReviewers(pullRequest.assignees)',
-        '_updateReviewers(pullRequest.approvals)'
+        '_updateReviewers(pullRequest.approvals)',
+        '_updateReviewers(approvals)'
       ],
       _updateReviewers: function() {
-        var approvals = this.pullRequest.approvals || {};
+        var approvals = this.approvals || this.pullRequest.approvals || {};
         this.sortedReviewers = this.pullRequest.assignees.map(function(assignee) {
           return {
             login: assignee.login,


### PR DESCRIPTION
After #294 the lgtm thumbs up icon was not shown anymore, this was due to the fact that the approvals object was not in use anymore, so I brought it back.

Edit: Sometimes it takes a while for it to shown (when loading the page), soon I get this message `failed: WebSocket is closed before the connection is established.` . I think this is the bug from http://stackoverflow.com/questions/12421993/firebase-websocket-is-closed-before-the-connection-is-established
