### PR TITLE
Update status when assignees are changed

### DIFF
--- a/src/projects/pull-request/pr-status.html
+++ b/src/projects/pull-request/pr-status.html
@@ -55,10 +55,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ></firebase-document>
 
     <list-item-label type="box" title="status">[[status]]</list-item-label>
-    <paper-dropdown-menu label="Set status" value="{{status}}" on-value-changed="_updateFirebaseStatus">
-      <paper-menu class="dropdown-content">
+    <paper-dropdown-menu label="Set status" on-value-changed="_updateFirebaseStatus">
+      <paper-menu id="statusList" class="dropdown-content" attr-for-selected="data-status">
         <template is="dom-repeat" items="[[statuses]]" index-as="index">
-          <paper-item>[[item]]</paper-item>
+          <paper-item data-status="[[item]]">[[item]]</paper-item>
         </template>
       </paper-menu>
     </paper-dropdown-menu>
@@ -76,7 +76,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
         },
         status: {
-          type: String
+          type: String,
+          notify: true
         },
         sendStatus: String,
         pullRequest: Object,
@@ -102,16 +103,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         return project.owner + '/' + project.name + '/pulls/' + pullRequest.number + '/status';
       },
       _updateFirebaseStatus: function(e) {
-        if (!e.detail.value) {
+        if (!e.detail.value || typeof this.retrievedStatus === 'object'
+            || e.detail.value === this.retrievedStatus || e.detail.value === this.status) {
           return;
         }
+        this.status = e.detail.value;
         this.$.setPrStatus.body = {
           status: this.status
         };
         this.$.setPrStatus.generateRequest();
       },
       _setStatus: function(retrievedStatus) {
-        this.status = (typeof retrievedStatus !== 'object') ? retrievedStatus : 'No reviewer assigned';
+        if (typeof retrievedStatus !== 'object') {
+          this.status = retrievedStatus;
+          this.select(this.status);
+        }
+      },
+      select: function(status) {
+        this.$.statusList.select(status);
       }
     });
   </script>

--- a/src/projects/pull-request/pull-request-general-information.html
+++ b/src/projects/pull-request/pull-request-general-information.html
@@ -136,8 +136,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           <pull-request-add-comments comments="{{comments}}" number="[[pullRequest.number]]"></pull-request-add-comments>
         </div>
         <div class="sidebar">
-          <pr-status pull-request="[[pullRequest]]"></pr-status>
-          <pull-request-reviewers editable="[[editable]]" pull-request="[[pullRequest]]"></pull-request-reviewers>
+          <pr-status id="PRStatus" pull-request="[[pullRequest]]" status="{{_prStatus}}"></pr-status>
+          <pull-request-reviewers
+              editable="[[editable]]" pull-request="[[pullRequest]]"
+              on-reviewers-updated="_updateReviewerStatus"></pull-request-reviewers>
           <tags-list>
             <template is="dom-repeat" items="[[issue.labels]]">
               <tag-list-item backgroundcolor="[[item.color]]">[[item.name]]</tag-list-item>
@@ -169,7 +171,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         pullRequest: {
           type: Object,
           notify: true
-        }
+        },
+        _prStatus: String
       },
       observers: [
         '_fireAjax(pullRequest)',
@@ -195,6 +198,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
       _prHasBeenMerged: function(e) {
         console.log(e);
+      },
+      _updateReviewerStatus: function(e) {
+        if (e.detail.length && this._prStatus === 'No reviewer assigned') {
+          this.$.PRStatus.select('Awaiting reviewer response');
+        }
       }
     });
   </script>

--- a/src/projects/pull-request/pull-request-reviewers.html
+++ b/src/projects/pull-request/pull-request-reviewers.html
@@ -95,6 +95,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
       _updateAssigneesList: function(e) {
         this.set('pullRequest.assignees', e.detail.response.assignees);
+        this.fire('reviewers-updated', e.detail.response.assignees);
       }
     });
   </script>


### PR DESCRIPTION
When you add a new assignee (and no assignees were selected) the PR status is now updated to "Awaiting reviewer response". Also I fixed the issue with not setting the value correctly in the dropdown-menu. Instead of binding to the read-only property `value`, we should select on the `paper-menu` instead.

Fixes #308 
Fixes #128 
