### PR TITLE
Finetune login process with Firebase

### DIFF
--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -83,16 +83,18 @@ of the GitHub oAuth token.
        * with the Firebase session and fires `github-token` again.
        */
       signIn: function(shouldRedirect) {
+        this.loading = true;
         this.$.auth.auth.getRedirectResult().then(function(result) {
-          this.loading = false;
           if (!result.credential) {
             if (this.signedIn && this._tokens.GitHub) {
               this.fire('github-token', this._tokens.GitHub);
+              this.loading = false;
             } else if (shouldRedirect) {
               this._redirectToGitHub();
             }
           } else {
             this._parseSuccesfulResult(result);
+            this.loading = false;
           }
         }.bind(this)).catch(function() {
           this.loading = false;
@@ -103,6 +105,8 @@ of the GitHub oAuth token.
         provider.addScope('user');
         provider.addScope('repo');
         this.$.auth.signInWithRedirect(provider);
+        // This will be called after the redirect has finished
+        this.signIn();
       },
       _parseSuccesfulResult: function(result) {
         var token = result.credential.accessToken;

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -105,8 +105,17 @@ Prism.languages.diff.other = /.+/m;
         flex: 1;
         display: flex;
       }
-      paper-spinner {
+      .loading {
         margin: auto;
+        height: 50px;
+        width: 100%;
+        text-align: center;
+      }
+      .loading span {
+        display: block;
+        margin-bottom: 10px;
+      }
+      paper-spinner {
         height: 50px;
         width: 50px;
       }
@@ -139,7 +148,10 @@ Prism.languages.diff.other = /.+/m;
         </template>
       </div>
 
-      <paper-spinner active="[[firebaseLoading]]" hidden$="[[!firebaseLoading]]"></paper-spinner>
+      <div class="loading" hidden$="[[!firebaseLoading]]">
+        <span>Logging in...</span>
+        <paper-spinner active></paper-spinner>
+      </div>
 
       <iron-lazy-pages selected="[[page.page]]"
                   attr-for-selected="data-route"
@@ -176,7 +188,9 @@ Prism.languages.diff.other = /.+/m;
       'go-login-github': '_signInWithGitHub'
     },
     attached: function() {
-      this.$.firebase.signIn(this.page.page !== '');
+      if (this.page.page !== '') {
+        this.$.firebase.signIn(true);
+      }
     },
     _equals: function(one, other) {
       return one === other;


### PR DESCRIPTION
Now after a redirect has been succesful, we immediately try to login (instead of relying on this handling in `rite-app`. Also the loading indication has been fixed and a paper spinner + loading text is now displayed while we are logging in. Also if you directly visit the home page, you are not logged in.

Fixes #296 
