### PR TITLE
Fix firebase redirect auto login

### DIFF
--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -105,8 +105,6 @@ of the GitHub oAuth token.
         provider.addScope('user');
         provider.addScope('repo');
         this.$.auth.signInWithRedirect(provider);
-        // This will be called after the redirect has finished
-        this.signIn();
       },
       _parseSuccesfulResult: function(result) {
         var token = result.credential.accessToken;

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -188,7 +188,9 @@ Prism.languages.diff.other = /.+/m;
       'go-login-github': '_signInWithGitHub'
     },
     attached: function() {
-      if (this.page.page !== '') {
+      if (document.referrer.indexOf('preview-code.firebaseapp.com') > -1) {
+        this.$.firebase.signIn(false);
+      } else if (this.page.page !== '') {
         this.$.firebase.signIn(true);
       }
     },


### PR DESCRIPTION
Now when you get redirected back to the app from Firebase, you are automatically logged in and meanwhile you view the logging in spinner.
