### PR TITLE
Fix position of preview icon for markdown-input

### DIFF
--- a/src/util/markdown-input.html
+++ b/src/util/markdown-input.html
@@ -38,7 +38,7 @@ after toggling the preview showing the rendered markdown in real-time.
   <template>
     <style>
       :host {
-        display: block;
+        display: flex;
         padding: 1em;
         padding-left: 0.5em;
         border: solid 1px transparent;
@@ -57,6 +57,7 @@ after toggling the preview showing the rendered markdown in real-time.
         flex: 1;
         line-height: 1.4em;
         padding-left: 0.5em;
+        min-width: 0;
       }
       paper-textarea {
         --paper-input-container: {


### PR DESCRIPTION
It was incorrectly added in #325. Now it is once again on the right of the input field
