### PR TITLE
When a pr is merged, the state is changed from opened to closed

### DIFF
--- a/src/projects/pull-request/pull-request-general-information.html
+++ b/src/projects/pull-request/pull-request-general-information.html
@@ -208,10 +208,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         return mergeable ? 'Merge pull request' : 'This branch has conflicts that must be resolved';
       },
       _prHasBeenMerged: function(e) {
-        if(e.detail.response.merged){
-          this.set('pullRequest.state','closed');
+        if (e.detail.response.merged) {
+          this.set('pullRequest.state', 'closed');
         }
-        console.log(e);
       },
       _updateReviewerStatus: function(e) {
         if (e.detail.length && this._prStatus === 'No reviewer assigned') {

--- a/src/projects/pull-request/pull-request-general-information.html
+++ b/src/projects/pull-request/pull-request-general-information.html
@@ -208,6 +208,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         return mergeable ? 'Merge pull request' : 'This branch has conflicts that must be resolved';
       },
       _prHasBeenMerged: function(e) {
+        if(e.detail.response.merged){
+          this.set('pullRequest.state','closed');
+        }
         console.log(e);
       },
       _updateReviewerStatus: function(e) {


### PR DESCRIPTION
Just a simple change, to change the state of the pull request when merging.
This makes sure there is feedback that the pr has been updated.

Fixes #330

---

Review this pull request [on Preview Code](https://preview-code.com/preview-code/rite-evaluation/pulls/333/overview).
