### PR TITLE
Hide approve button when creating a PR

### DIFF
--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -208,6 +208,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         },
         _canUserApprove: {
           type: Boolean,
+          value: false,
           computed: '_getCanUserApprove(pullRequest.assignees, githubUser, approvable)'
         },
         _approved: {


### PR DESCRIPTION
Fixes #338 

Previously, the 'thumbs up' button was visible when creating a PR because the `_getCanUserApprove` computed property did not fire.
