### PR TITLE
Add option to log in with only public repository access

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,12 +19,11 @@
   ],
   "dependencies": {
     "paper-elements": "polymerelements/paper-elements#^1.0.7",
-    "carbon-elements": "polymerelements/carbon-elements#^0.1.0",
     "iron-elements": "polymerelements/iron-elements#^1.0.10",
     "app-route": "TimvdLippe/app-route#parent-active-propagation",
     "iron-lazy-pages": "^1.0.2",
     "Sortable": "Rubaxa/Sortable#dev",
-    "marked-element": "TimvdLippe/marked-element#expose-callback",
+    "marked-element": "polymerelements/marked-element#^1.2.0",
     "prism-element": "polymerelements/prism-element#^1.1.0",
     "polymerfire": "firebase/polymerfire#^0.9.2",
     "prism": "1.5.1",

--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -82,7 +82,7 @@ of the GitHub oAuth token.
        * Else it checks for local storage if the token existed and signed in
        * with the Firebase session and fires `github-token` again.
        */
-      signIn: function(shouldRedirect) {
+      signIn: function(shouldRedirect, privateRepos) {
         this.loading = true;
         this.$.auth.auth.getRedirectResult().then(function(result) {
           if (!result.credential) {
@@ -90,7 +90,7 @@ of the GitHub oAuth token.
               this.fire('github-token', this._tokens.GitHub);
               this.loading = false;
             } else if (shouldRedirect) {
-              this._redirectToGitHub();
+              this._redirectToGitHub(privateRepos);
             }
           } else {
             this._parseSuccesfulResult(result);
@@ -100,10 +100,14 @@ of the GitHub oAuth token.
           this.loading = false;
         });
       },
-      _redirectToGitHub: function() {
+      _redirectToGitHub: function(privateRepos) {
         var provider = new firebase.auth.GithubAuthProvider();
         provider.addScope('user');
-        provider.addScope('repo');
+        if (privateRepos) {
+          provider.addScope('repo');
+        } else {
+          provider.addScope('public_repo');
+        }
         this.$.auth.signInWithRedirect(provider);
       },
       _parseSuccesfulResult: function(result) {

--- a/src/home-page.html
+++ b/src/home-page.html
@@ -63,6 +63,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       .name {
         margin-top:3%;
       }
+      .flex {
+        display: flex;
+        max-width: 500px;
+        margin: 0 auto;
+      }
+      .note {
+        font-size: 13px;
+      }
     </style>
 
     <h1 class="name">PReview Code</h1>
@@ -70,12 +78,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <img class="logo" src="https://blueseptember.org.au/wp-content/uploads/2015/07/Blue-square.jpg" />
     </div>
     <div class="button-container">
-      <paper-button raised on-tap="_loginWithGithub">
-        <img height=30px src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" /> Login with Github
-      </paper-button>
-      <paper-button raised disabled title="Support coming soon!">
-        <img height=30px src="https://pbs.twimg.com/profile_images/615675308243488768/_d8TRzzL.png" /> Login with Bitbucket
-      </paper-button>
+      <div>
+        <h4>Log in with GitHub</h4>
+        <div class="flex">
+          <div>
+            <paper-button raised on-tap="_loginWithGithubPrivate">
+              <img height=30px src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" /> Private access
+            </paper-button>
+            <div class="note">Private access includes all private repositories. See <a href="https://developer.github.com/v3/oauth/#scopes" target="_blank">GitHub scope</a> 'repo'.</div>
+          </div>
+          <div>
+            <paper-button raised on-tap="_loginWithGithubPublic">
+              <img height=30px src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" /> Public access
+            </paper-button>
+            <div class="note">Public access does not include private repositories. See <a href="https://developer.github.com/v3/oauth/#scopes" target="_blank">GitHub scope</a> 'public_repo'.</div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h4>Log in with BitBucket</h4>
+        <paper-button raised disabled>
+          <img height=30px src="https://pbs.twimg.com/profile_images/615675308243488768/_d8TRzzL.png" /> Coming soon
+        </paper-button>
+      </div>
     </div>
     <div class="about">
       <h2>About us</h2>
@@ -92,8 +117,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script>
     Polymer({
       is: 'home-page',
-      _loginWithGithub: function() {
-        this.fire('go-login-github');
+      _loginWithGithubPrivate: function() {
+        this.fire('go-login-github', true);
+      },
+      _loginWithGithubPublic: function() {
+        this.fire('go-login-github', false);
       }
     });
   </script>

--- a/src/rite-app.html
+++ b/src/rite-app.html
@@ -197,8 +197,8 @@ Prism.languages.diff.other = /.+/m;
     _equals: function(one, other) {
       return one === other;
     },
-    _signInWithGitHub: function() {
-      this.$.firebase.signIn(true);
+    _signInWithGitHub: function(e) {
+      this.$.firebase.signIn(true, e.detail);
     },
     _setToken: function(e) {
       this.$.authenticatedAjax.storeToken(e.detail);


### PR DESCRIPTION
You should now be able to log in with GitHub and only allowing public repositories to be shared.

Note: build is failing due to `carbon-elements` missing, this should be changed from `carbon-` to `app-`
