### PR TITLE
Fix signin flow in presence of Public and Private access

### DIFF
--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -107,7 +107,7 @@ of the GitHub oAuth token.
       checkSignedIn: function() {
         this.loading = true;
         this.$.auth.auth.getRedirectResult().then(function(result) {
-          redirectDone = !!result.credential
+          var redirectDone = !!result.credential;
           if (redirectDone) {
             this._parseSuccesfulResult(result);
           } else {
@@ -127,14 +127,6 @@ of the GitHub oAuth token.
         this._setEmptyTokens();
         return this.$.auth.auth.signOut();
       },
-
-      _redirectToGitHub: function(privateRepos) {
-        var provider = new firebase.auth.GithubAuthProvider();
-        provider.addScope('user');
-        if (privateRepos) {
-          provider.addScope('repo');
-        } else {
-          provider.addScope('public_repo');
 
       /**
        * When Firebase confirms the user is signed in (via the signedIn property)

--- a/src/ajax/firebase-authentication.html
+++ b/src/ajax/firebase-authentication.html
@@ -48,7 +48,7 @@ of the GitHub oAuth token.
     </firebase-app>
     <firebase-auth id="auth"
         app-name="preview-code"
-        user="{{user}}" provider="github"
+        provider="github"
         signed-in="{{signedIn}}"
         ></firebase-auth>
     <iron-localstorage name="token-storage"
@@ -70,40 +70,64 @@ of the GitHub oAuth token.
           type: Boolean,
           notify: true
         },
-        _tokens: Object
+        signedIn: Boolean,
+        _tokens: Object,
+        waitingForSignIn: Boolean
       },
+
+      observers: [
+        '_onSignInChange(waitingForSignIn, signedIn)'
+      ],
+
       attached: function() {
         this._parseSuccesfulResult = this._parseSuccesfulResult.bind(this);
       },
+
       /**
-       * Sign in the user with Firebase. It checks if the redirect was succesful.
-       * If that is true, fire `github-token` event with the new token.
-       *
-       * Else it checks for local storage if the token existed and signed in
-       * with the Firebase session and fires `github-token` again.
+       * Perform an auth using a redirect-based sign-in flow.
        */
-      signIn: function(shouldRedirect, privateRepos) {
+      doSignIn: function(privateRepoAccess) {
+        var provider = new firebase.auth.GithubAuthProvider();
+        provider.addScope('user');
+        if (privateRepoAccess) {
+          provider.addScope('repo');
+        } else {
+          provider.addScope('public_repo');
+        }
+        this.$.auth.signInWithRedirect(provider);
+      },
+
+      /**
+       * Check whether the redirect-flow was just finished.
+       * In this case, parse the just obtained GitHub token and continue.
+       * Otherwise, either the user was already signed in, or never signed in.
+       * If the GitHub token is present in local-storage, we wait for firebase
+       * to confirm the signin. If not, we notify that the user was not signed in.
+       */
+      checkSignedIn: function() {
         this.loading = true;
         this.$.auth.auth.getRedirectResult().then(function(result) {
-          if (!result.credential) {
-            if (this.signedIn && this._tokens.GitHub) {
-              this.fire('github-token', this._tokens.GitHub);
-              this.loading = false;
-            } else if (shouldRedirect) {
-              this._redirectToGitHub(privateRepos);
-            }
-          } else {
+          redirectDone = !!result.credential
+          if (redirectDone) {
             this._parseSuccesfulResult(result);
-            this.loading = false;
+          } else {
+            if (this._tokens.GitHub) {
+              this.waitingForSignIn = true;
+            } else {
+              this.fire('check-signed-in-failed');
+            }
           }
+          this.loading = false;
         }.bind(this)).catch(function() {
           this.loading = false;
         });
       },
+
       signOut: function() {
         this._setEmptyTokens();
         return this.$.auth.auth.signOut();
       },
+
       _redirectToGitHub: function(privateRepos) {
         var provider = new firebase.auth.GithubAuthProvider();
         provider.addScope('user');
@@ -111,14 +135,24 @@ of the GitHub oAuth token.
           provider.addScope('repo');
         } else {
           provider.addScope('public_repo');
+
+      /**
+       * When Firebase confirms the user is signed in (via the signedIn property)
+       * then continue with the current GitHub token from local storage.
+       */
+      _onSignInChange: function(waitingForSignIn, signedIn) {
+        if (!waitingForSignIn) return;
+        if (signedIn) {
+          this.fire('github-token', this._tokens.GitHub);
         }
-        this.$.auth.signInWithRedirect(provider);
       },
+
       _parseSuccesfulResult: function(result) {
         var token = result.credential.accessToken;
         this.set('_tokens.GitHub', token);
         this.fire('github-token', token);
       },
+
       _setEmptyTokens: function() {
         this._tokens = {
           GitHub: ''

--- a/src/preview-app.html
+++ b/src/preview-app.html
@@ -196,20 +196,18 @@ Prism.languages.diff.other = /.+/m;
     },
     listeners: {
       'github-token': '_setToken',
-      'go-login-github': '_signInWithGitHub'
+      'go-login-github': '_signInWithGitHub',
+      'check-signed-in-failed': '_toHome'
     },
     attached: function() {
-      if (document.referrer.indexOf('preview-code.firebaseapp.com') > -1) {
-        this.$.firebase.signIn(false);
-      } else if (this.page.page !== '') {
-        this.$.firebase.signIn(true);
-      }
+      // On page-load, we may or may not be signed in.
+      this.$.firebase.checkSignedIn();
     },
     _equals: function(one, other) {
       return one === other;
     },
     _signInWithGitHub: function(e) {
-      this.$.firebase.signIn(true, e.detail);
+      this.$.firebase.doSignIn(e.detail);
     },
     _signout: function() {
       this.$.firebase.signOut().then(function() {
@@ -220,6 +218,9 @@ Prism.languages.diff.other = /.+/m;
       this.$.authenticatedAjax.storeToken(e.detail);
       this.set('page.page', 'projects');
       this.$.ajaxGithubUser.generateRequest();
+    },
+    _toHome: function() {
+      this.set('page.page', '');
     }
   });
   </script>

--- a/src/preview-app.html
+++ b/src/preview-app.html
@@ -201,7 +201,9 @@ Prism.languages.diff.other = /.+/m;
     },
     attached: function() {
       // On page-load, we may or may not be signed in.
-      this.$.firebase.checkSignedIn();
+      if (this.page.page !== '' || document.referrer.indexOf('preview-code.firebaseapp.com') > -1) {
+        this.$.firebase.checkSignedIn();
+      }
     },
     _equals: function(one, other) {
       return one === other;


### PR DESCRIPTION
I split the sign-in functionality (previously all in `signIn()`) into two functions. One (`doSignIn`) performs the redirect-flow if and only if the user clicks one of the login buttons on the home page. The other (`checkSignedIn`) checks whether the redirect-flow was done and if the user is signed in properly.

If a user was not signed in (no GitHub token in local-store and no redirect-flow ongoing), then the user is redirected to the home page again.

Please check thoroughly!
