### PR TITLE
The status can be set, even if the pr is not made with the tool.

### DIFF
--- a/src/projects/pull-request/pr-status.html
+++ b/src/projects/pull-request/pr-status.html
@@ -103,8 +103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         return project.owner + '/' + project.name + '/pulls/' + pullRequest.number + '/status';
       },
       _updateFirebaseStatus: function(e) {
-        if (!e.detail.value || typeof this.retrievedStatus === 'object'
-            || e.detail.value === this.retrievedStatus || e.detail.value === this.status) {
+        if (!e.detail.value || e.detail.value === this.retrievedStatus || e.detail.value === this.status) {
           return;
         }
         this.status = e.detail.value;
@@ -117,6 +116,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         if (typeof retrievedStatus !== 'object') {
           this.status = retrievedStatus;
           this.select(this.status);
+        } else {
+          this.status = ' ';
         }
       },
       select: function(status) {


### PR DESCRIPTION
This also fixes the bug, that if no status is set the status of the previous pr is shown. 
Fixes #329

An if check is removed, which is only false at pageload.
Then the status of firebase is not yet fetched, this changed so quickly that the user can not select a status already.
Maybe a better solution can be found, although I can not think of a immediate problem with the current solution.

---

Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/frontend/pulls/379/overview).
