### PR TITLE
Only show the move group icon when in pr creation

### DIFF
--- a/src/projects/diff/group.html
+++ b/src/projects/diff/group.html
@@ -251,7 +251,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           container.appendChild(dragHandle);
           hunkElem.setAttribute('class', 'edit-mode');
         } else {
-          hunkElem.approvable = true;
+          hunkElem.nonEdit = true;
         }
         container.appendChild(hunkElem);
         return container;

--- a/src/projects/diff/highlight.html
+++ b/src/projects/diff/highlight.html
@@ -180,7 +180,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           </a>
         </span>
         <span class="btns">
-          <paper-icon-button noink icon="icons:tab" title="Move this change to another group" on-tap="_promptToMove"></paper-icon-button>
+          <paper-icon-button noink icon="icons:tab" title="Move this change to another group" on-tap="_promptToMove" hidden$="[[nonEdit]]"></paper-icon-button>
           <paper-icon-button noink icon="icons:thumb-up" title="Approve this change"
             hidden$="[[!_canUserApprove]]" toggles active="{{_approved}}"></paper-icon-button>
         </span>
@@ -207,14 +207,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         hunk: Object,
         pullRequest: Object,
         collapsed: Boolean,
-        approvable: {
+        nonEdit: {
           type: Boolean,
           value: false
         },
         _canUserApprove: {
           type: Boolean,
           value: false,
-          computed: '_getCanUserApprove(pullRequest.assignees, githubUser, approvable)'
+          computed: '_getCanUserApprove(pullRequest.assignees, githubUser, nonEdit)'
         },
         _approved: {
           type: Boolean,

--- a/test/projects/diff/highlight.html
+++ b/test/projects/diff/highlight.html
@@ -127,7 +127,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               name: 'hunk'
             }
           };
-          elem.approvable = true;
+          elem.nonEdit = true;
           elem.collapsed = false;
           button = elem.$$('[icon="icons:thumb-up"]');
         });
@@ -136,8 +136,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           assert.equal(button.hidden, false);
         });
 
-        test('not when not approvable', function() {
-          elem.approvable = false;
+        test('not when not nonEdit', function() {
+          elem.nonEdit = false;
           assert.equal(button.hidden, true);
         });
 


### PR DESCRIPTION
Now the move group icon is shown when looking at the pr.
The button gives a non-functional pop-up (disappears when trying to select anything). Therefore the button should be removed from this view.

We already had an attribute that new if we were in edit mode or not.
I renamed it, to make it applicable for a bigger purpose.  

---

Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/frontend/pulls/380/overview).
