### PR TITLE
Imports pull requests from github and add's them to firebase

### DIFF
--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../../bower_components/polymerfire/firebase-document.html">
+<link rel="import" href="../../ajax/backend-ajax.html">
 <link rel="import" href="../project-behavior.html">
 
 <dom-module id="hunk-sorter">
@@ -37,6 +38,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       path="[[_remoteOrderingPath]]"
       data="{{_remoteOrdering}}"
       ></firebase-document>
+      <backend-ajax
+        id="checkIfPathIsThere"
+        refurl="[[backendPath]]"
+        ></backend-ajax>
+
   </template>
   <script>
   /*global ProjectBehavior*/
@@ -59,6 +65,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         _remoteOrderingPath: {
           type: String,
           computed: '_getOrderingPath(project, pullRequest)'
+        },
+        backendPath: {
+          type: String,
+          computed: '_updateBackendPath(project, pullRequest)'
         }
       },
       observers: [
@@ -159,6 +169,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         if (unsortedGroup.diff.length > 0) {
           allGroups.push(unsortedGroup);
         }
+        if (fbOrdering.groups === undefined && this.backendPath && defaultGroup.diff.length > 0) {
+          this.$.checkIfPathIsThere.body = defaultGroup;
+          this.$.checkIfPathIsThere.generateRequest();
+        }
+
         this.set('groups', allGroups);
       },
 
@@ -256,6 +271,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             return f(i, this.groups[i]);
           }
         }
+      },
+
+      _updateBackendPath: function(project, pullRequest) {
+        return project.owner + '/' + project.name + '/pulls/' + pullRequest.number + '/check';
       },
 
       /**

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -141,7 +141,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         return project.owner + '/' + project.name + '/pulls/' + pullRequest.number + '/ordering';
       },
       _getOrderingFromFirebaseObj: function(fbOrdering) {
-        var defaultGroupName = 'Unsorted changes';
+        var defaultGroupName = 'Imported from Github';
         var ordering = [];
         if (fbOrdering.lastChanged) {
           defaultGroupName = 'New changes since: ' + fbOrdering.lastChanged;

--- a/src/projects/pull-request/pull-request-add-comments.html
+++ b/src/projects/pull-request/pull-request-add-comments.html
@@ -61,7 +61,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <backend-ajax
      id="postGroupComment"
      refurl="[[backendPath]]/group"
-     on-response="_setGroupComments"
      ></backend-ajax>
 
     <markdown-input markdown="{{newtext}}" label="Leave a comment."></markdown-input>
@@ -110,9 +109,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       },
       _setGeneralComments: function(e) {
         this.push('comments', e.detail.response);
-      },
-      _setGroupComments: function(e) {
-        this.push('comments', {groupID: this.group.id, comment: e.detail.response});
       }
     });
   </script>

--- a/test/projects/diff/diff.html
+++ b/test/projects/diff/diff.html
@@ -115,7 +115,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             oldIndex: 1,
             newIndex: 0
           });
-          assert.equal(element.orderedGroups[0].info.title, 'Unsorted changes');
+          assert.equal(element.orderedGroups[0].info.title, 'Imported from Github');
           done();
         });
         element.addEventListener('iron-overlay-closed', function() {
@@ -157,7 +157,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       test('creates ordering from groups and hunks', function() {
         var ordering = element.getOrdering();
         assert.equal(ordering.length, 1);
-        assert.equal(ordering[0].info.title, 'Unsorted changes');
+        assert.equal(ordering[0].info.title, 'Imported from Github');
         assert.equal(ordering[0].diff.length, 2);
       })
 


### PR DESCRIPTION
If a pull request is made via github no data is stored in firebase.
This means that certain features won't work, because the path in firebase does not exists. Therefore (pr specific) default data is stored in firebase, when there is no data stored.

Together with preview-code/backend#16
fixes #382

---

Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/frontend/pulls/387/overview).
