### PR TITLE
Fixes the issue of having to double click

### DIFF
--- a/src/util/markdown-input.html
+++ b/src/util/markdown-input.html
@@ -82,7 +82,7 @@ after toggling the preview showing the rendered markdown in real-time.
       }
     </style>
     <div class="edit-area">
-      <paper-textarea id="textarea" hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}" on-blur="_blurred"></paper-textarea>
+      <paper-textarea hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
       <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]"></marked-github-element>
     </div>
     <paper-icon-button toggles icon="icons:visibility" hidden$="[[hideEdit]]" active="{{previewToggle}}" title="Toggle Markdown preview">[[_toggleText]]</paper-icon-button>
@@ -116,8 +116,7 @@ after toggling the preview showing the rendered markdown in real-time.
         label: String,
         previewToggle: {
           type: Boolean,
-          notify: true,
-          observer: '_previewToggleChanged'
+          notify: true
         },
         _hidePreview: {
           type: Boolean,
@@ -131,12 +130,6 @@ after toggling the preview showing the rendered markdown in real-time.
           type: Boolean,
           computed: '_showEdit(disabled, previewToggle)'
         }
-      },
-      _previewToggleChanged: function(newValue) {
-        if (newValue)
-          return;
-        this.$.textarea.$.input.$.textarea.setSelectionRange(0, 0);
-        this.$.textarea.focus();
       },
       _getHidePreview: function(previewToggle, disabled) {
         var shouldBeHidden = !disabled && !previewToggle;
@@ -154,11 +147,6 @@ after toggling the preview showing the rendered markdown in real-time.
           return !disabled;
         }
         return previewToggle;
-      },
-      _blurred: function() {
-        if (!(this.markdown.trim()))
-          return;
-        this.previewToggle = !this.previewToggle;
       }
     });
   </script>

--- a/src/util/markdown-input.html
+++ b/src/util/markdown-input.html
@@ -82,7 +82,7 @@ after toggling the preview showing the rendered markdown in real-time.
       }
     </style>
     <div class="edit-area">
-      <paper-textarea hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
+      <paper-textarea id="textarea" hidden$="[[!_hidePreview]]" label="[[label]]" value="{{markdown}}"></paper-textarea>
       <marked-github-element hidden$="[[_hidePreview]]" markdown="[[markdown]]"></marked-github-element>
     </div>
     <paper-icon-button toggles icon="icons:visibility" hidden$="[[hideEdit]]" active="{{previewToggle}}" title="Toggle Markdown preview">[[_toggleText]]</paper-icon-button>
@@ -116,7 +116,8 @@ after toggling the preview showing the rendered markdown in real-time.
         label: String,
         previewToggle: {
           type: Boolean,
-          notify: true
+          notify: true,
+          observer: '_previewToggleChanged'
         },
         _hidePreview: {
           type: Boolean,
@@ -130,6 +131,13 @@ after toggling the preview showing the rendered markdown in real-time.
           type: Boolean,
           computed: '_showEdit(disabled, previewToggle)'
         }
+      },
+     _previewToggleChanged: function(newValue) {
+       if (newValue){
+         return;
+       }
+      this.$.textarea.$.input.$.textarea.setSelectionRange(0, 0);
+      this.$.textarea.focus();
       },
       _getHidePreview: function(previewToggle, disabled) {
         var shouldBeHidden = !disabled && !previewToggle;


### PR DESCRIPTION
Fixes #378

This pr removes the off-focus/blurring when click outside a markdown-input.
The way it was implemented caused these problems.

We might want to add it later, although I do not see a high priority 

---
Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/frontend/pulls/416/overview).