### PR TITLE
Do not show empty group

### DIFF
--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -160,7 +160,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         var allGroups = [];
         for (var i = 0, l = ordering.length; i < l; i++) {
           var group = this._reconstructGroup(ordering[i], unsortedHunks);
-          if (group) {
+          if (group && group.diff > 0) {
             allGroups.push(group);
           }
         }

--- a/src/projects/diff/hunk-sorter.html
+++ b/src/projects/diff/hunk-sorter.html
@@ -160,7 +160,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         var allGroups = [];
         for (var i = 0, l = ordering.length; i < l; i++) {
           var group = this._reconstructGroup(ordering[i], unsortedHunks);
-          if (group && group.diff > 0) {
+          if (group && group.diff && group.diff.length> 0) {
             allGroups.push(group);
           }
         }


### PR DESCRIPTION
This error was caused, when all items of a group where transferd to the "new changes since" group.

Fixes #419

---
Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/frontend/pulls/434/overview).