### PR TITLE
The commit message is visable again

### DIFF
--- a/src/projects/pull-request/pull-request-commit.html
+++ b/src/projects/pull-request/pull-request-commit.html
@@ -52,11 +52,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         };
       }
       .container.false {
-        height: 1.25em;
-        line-height: 1.25;
+        margin-top: -1em;
+        height: 64px;
+        line-height: 1.25em;
         overflow: hidden;
       }
       .container.true {
+        margin-top: -1em;
         height: auto;
         overflow: hidden;
       }


### PR DESCRIPTION
I have no idea why it didn't work, something with markdown-input I suppose.
I have made the commit message as long as the image on the left side.

fixes #408