### PR TITLE
Fix feature-bar to always collapse

### DIFF
--- a/src/projects/feature-bar.html
+++ b/src/projects/feature-bar.html
@@ -109,6 +109,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           }
           Polymer.dom(this.$.tabs).appendChild(tab);
         }.bind(this));
+
+        window.requestAnimationFrame(function() {
+          this._toggleCollapsed(this.collapsed);
+        }.bind(this));
       },
 
       _toggleCollapsed: function(collapsed) {


### PR DESCRIPTION
Before this fix, the bar would not collapse when attached in collapsed state. It would only do so if the state changed to `collapsed` when the element was already attached